### PR TITLE
Fixup python3 idioms

### DIFF
--- a/pcapng/blocks.py
+++ b/pcapng/blocks.py
@@ -105,7 +105,7 @@ class SectionHeader(Block):
     def register_interface(self, interface):
         """Helper method to register an interface within this section"""
         assert isinstance(interface, InterfaceDescription)
-        interface_id = self._interfaces_id.next()
+        interface_id = next(self._interfaces_id)
         interface.interface_id = interface_id
         self.interfaces[interface_id] = interface
 

--- a/pcapng/structs.py
+++ b/pcapng/structs.py
@@ -186,7 +186,7 @@ class StructField(object):
         return '{0}()'.format(self.__class__.__name__)
 
     def __unicode__(self):
-        return unicode(self.__repr__())
+        return self.__repr__().encode('UTF-8')
 
 
 class RawBytes(StructField):
@@ -573,7 +573,7 @@ class Options(Mapping):
             return ftype(value, self.endianness)
 
         if ftype in ('str', 'string', 'unicode'):
-            return unicode(value, encoding='utf-8')
+            return value.decode('utf-8')
 
         _numeric_types = {
             'u8': 'B', 'i8': 'b',


### PR DESCRIPTION
here's 2 simple changes that allow pcapng to build and work on python3.  Tested in python3.4, and python 2.7 on Ubuntu