### PR TITLE
Add pcapng write support

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 parallel = False
+source = pcapng
 
 [report]
 exclude_lines =

--- a/README.rst
+++ b/README.rst
@@ -141,27 +141,41 @@ Hacking
 
 Format specification is here:
 
-http://www.winpcap.org/ntar/draft/PCAP-DumpFileFormat.html
+https://github.com/pcapng/pcapng/
 
 Contributions are welcome, please contact me if you're planning to do
 some big change, so that we can sort out the best way to integrate it.
 
-Or even better, open an issue so the whole world can partecipate in
+Or even better, open an issue so the whole world can participate in
 the discussion :)
 
 
 Pcap-ng write support
 =====================
 
-Support for writing pcap-ng files is "planned"; that means: I have
-some ideas on how to write that part and which would be the required
-changes to the library.
+Write support exists as of version x.y.z. See the file
+``examples/generate_pcapng.py`` for an example of the minimum code
+needed to generate a pcapng file.
 
-I didn't add that part (yet) as I currently don't need it, and I'm
-wondering whether anybody might (possible use cases are if you're
-writing some packet capture tool in Python, or some other kind of
-capture-file manipulation thing).
+In most cases, this library will prevent you from creating broken
+data. If you want to create marginal pcapng files, e.g. as test cases
+for other software, you can do that by adjusting the "strictness" of
+the library, as in:
 
-If you need this feature, I'd like to hear from you (otherwise, I
-don't really think I'm going to invest much time in something that no
-one needs..).
+.. code-block:: python
+
+    import pcapng.strictness as strictness
+    strictness.strictness = strictness.STRICTNESS_FIX
+
+Recognized values are ``STRICTNESS_FORBID`` (the default),
+``STRICTNESS_FIX`` (warn about problems, fix *if possible*),
+``STRICTNESS_WARN`` (warn only), and ``STRICTNESS_NONE`` (no warnings).
+Circumstances that will result in strictness warnings include:
+
+    * Adding multiples of a non-repeatable option to a block
+
+    * Adding a SPB to a file with more than one interface
+
+    * Writing a PB (PBs are obsolete and not to be used in new files)
+
+    * Writing EPB/SPB/PB/ISB before writing any IDBs

--- a/README.rst
+++ b/README.rst
@@ -164,12 +164,12 @@ the library, as in:
 
 .. code-block:: python
 
-    import pcapng.strictness as strictness
-    strictness.strictness = strictness.STRICTNESS_FIX
+    from pcapng.strictness import Strictness, set_strictness
+    set_strictness(Strictness.FIX)
 
-Recognized values are ``STRICTNESS_FORBID`` (the default),
-``STRICTNESS_FIX`` (warn about problems, fix *if possible*),
-``STRICTNESS_WARN`` (warn only), and ``STRICTNESS_NONE`` (no warnings).
+Recognized values are ``Strictness.FORBID`` (the default),
+``Strictness.FIX`` (warn about problems, fix *if possible*),
+``Strictness.WARN`` (warn only), and ``Strictness.NONE`` (no warnings).
 Circumstances that will result in strictness warnings include:
 
     * Adding multiples of a non-repeatable option to a block

--- a/examples/dump_pcapng_info_pretty.py
+++ b/examples/dump_pcapng_info_pretty.py
@@ -7,7 +7,6 @@ from datetime import datetime
 # To make sure all packet types are available
 import scapy.all  # noqa
 import scapy.packet
-import six
 from scapy.layers.l2 import Ether
 
 import pcapng
@@ -125,8 +124,8 @@ def pprint_enhanced_packet(block):
         text.extend(
             [
                 col256("NIC:", bold=True),
-                col256(six.u(block.interface_id), fg="145"),
-                col256(six.u(block.interface.options["if_name"]), fg="140"),
+                col256(block.interface_id, fg="145"),
+                col256(block.interface.options["if_name"], fg="140"),
             ]
         )
     except KeyError:
@@ -207,7 +206,7 @@ def format_scapy_packet(packet):
 
 
 def make_printable(data):  # todo: preserve unicode
-    stream = six.StringIO()
+    stream = io.StringIO()
     for ch in data:
         if ch == "\\":
             stream.write("\\\\")
@@ -219,7 +218,7 @@ def make_printable(data):  # todo: preserve unicode
 
 
 def format_binary_data(data):
-    stream = six.BytesIO(data)
+    stream = io.BytesIO(data)
     row_offset = 0
     row_size = 16  # bytes
 
@@ -228,8 +227,8 @@ def format_binary_data(data):
         if not data:
             return
 
-        hexrow = six.BytesIO()
-        asciirow = six.BytesIO()
+        hexrow = io.BytesIO()
+        asciirow = io.BytesIO()
         for i, byte in enumerate(data):
             if 32 <= ord(byte) <= 126:
                 asciirow.write(byte)

--- a/examples/dump_pcapng_info_pretty.py
+++ b/examples/dump_pcapng_info_pretty.py
@@ -7,6 +7,7 @@ from datetime import datetime
 # To make sure all packet types are available
 import scapy.all  # noqa
 import scapy.packet
+import six
 from scapy.layers.l2 import Ether
 
 import pcapng
@@ -120,6 +121,16 @@ def pprint_enhanced_packet(block):
             fg="455",
         ),
     ]
+    try:
+        text.extend(
+            [
+                col256("NIC:", bold=True),
+                col256(six.u(block.interface_id), fg="145"),
+                col256(six.u(block.interface.options["if_name"]), fg="140"),
+            ]
+        )
+    except KeyError:
+        pass
 
     text.extend(
         [
@@ -196,7 +207,7 @@ def format_scapy_packet(packet):
 
 
 def make_printable(data):  # todo: preserve unicode
-    stream = io.BytesIO(data)
+    stream = six.StringIO()
     for ch in data:
         if ch == "\\":
             stream.write("\\\\")
@@ -208,7 +219,7 @@ def make_printable(data):  # todo: preserve unicode
 
 
 def format_binary_data(data):
-    stream = io.BytesIO(data)
+    stream = six.BytesIO(data)
     row_offset = 0
     row_size = 16  # bytes
 
@@ -217,8 +228,8 @@ def format_binary_data(data):
         if not data:
             return
 
-        hexrow = io.BytesIO()
-        asciirow = io.BytesIO()
+        hexrow = six.BytesIO()
+        asciirow = six.BytesIO()
         for i, byte in enumerate(data):
             if 32 <= ord(byte) <= 126:
                 asciirow.write(byte)

--- a/examples/generate_pcapng.py
+++ b/examples/generate_pcapng.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import argparse
+
+import pcapng.blocks as blocks
+
+parser = argparse.ArgumentParser()
+parser.add_argument("outfile", type=argparse.FileType("wb"))
+args = parser.parse_args()
+
+shb = blocks.SectionHeader(
+    options={
+        "shb_hardware": "artificial",
+        "shb_os": "python",
+        "shb_userappl": "python-pcapng",
+    }
+)
+shb.write(args.outfile)
+idb = shb.new_member(
+    blocks.InterfaceDescription,
+    link_type=1,
+    options={"if_description": "Hand-rolled", "if_os": "Python"},
+)
+idb.write(args.outfile)
+
+
+# fmt: off
+test_pl = (
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff,     # dest MAC
+        0x11, 0x22, 0x33, 0xdd, 0xaa, 0x00,     # src MAC
+        0x08, 0x00,                             # ethertype (ipv4)
+        0x45, 0x00, 0x00, 31,                   # IP start
+        0x00, 0x00, 0x00, 0x00,                 # ID+flags
+        0xfe, 17,                               # TTL, UDP
+        0x00, 0x00,                             # checksum
+        127, 0, 0, 1,                           # src IP
+        127, 0, 0, 2,                           # dst IP
+        0x12, 0x34, 0x56, 0x78,                 # src/dst ports
+        0x00, 11,                               # length
+        0x00, 0x00,                             # checksum
+        0x44, 0x41, 0x50,                       # Payload
+)
+# fmt: on
+
+spb = shb.new_member(blocks.SimplePacket)
+spb.packet_data = bytes(test_pl)
+spb.write(args.outfile)

--- a/examples/generate_pcapng.py
+++ b/examples/generate_pcapng.py
@@ -3,6 +3,7 @@
 import argparse
 
 import pcapng.blocks as blocks
+from pcapng import FileWriter
 
 parser = argparse.ArgumentParser()
 parser.add_argument("outfile", type=argparse.FileType("wb"))
@@ -15,14 +16,14 @@ shb = blocks.SectionHeader(
         "shb_userappl": "python-pcapng",
     }
 )
-shb.write(args.outfile)
 idb = shb.new_member(
     blocks.InterfaceDescription,
     link_type=1,
     options={"if_description": "Hand-rolled", "if_os": "Python"},
 )
-idb.write(args.outfile)
 
+# FileWriter() immediately writes the SHB and any IDBs you've added to it
+writer = FileWriter(args.outfile, shb)
 
 # fmt: off
 test_pl = (
@@ -44,4 +45,4 @@ test_pl = (
 
 spb = shb.new_member(blocks.SimplePacket)
 spb.packet_data = bytes(test_pl)
-spb.write(args.outfile)
+writer.write_block(spb)

--- a/pcapng/__init__.py
+++ b/pcapng/__init__.py
@@ -5,3 +5,4 @@
 # ----------------------------------------------------------------------
 
 from .scanner import FileScanner  # noqa
+from .writer import FileWriter  # noqa

--- a/pcapng/_compat.py
+++ b/pcapng/_compat.py
@@ -1,0 +1,16 @@
+from collections import namedtuple as _namedtuple
+
+
+# version-portable namedtuple with defaults
+def namedtuple(typename, field_names, defaults=None):
+    if not defaults:
+        # No defaults given or needed
+        return _namedtuple(typename, field_names)
+    try:
+        # Python 3.7+
+        return _namedtuple(typename, field_names, defaults=defaults)
+    except TypeError:
+        T = _namedtuple(typename, field_names)
+        # Python 2.7, up to 3.6
+        T.__new__.__defaults__ = defaults
+        return T

--- a/pcapng/blocks.py
+++ b/pcapng/blocks.py
@@ -13,16 +13,21 @@ better access to decoded information, ...
 import io
 import itertools
 
+from pcapng import strictness as strictness
 from pcapng.constants import link_types
 from pcapng.structs import (
     IntField,
     ListField,
     NameResolutionRecordField,
+    Option,
+    Options,
     OptionsField,
-    PacketDataField,
+    PacketBytes,
     RawBytes,
-    SimplePacketDataField,
+    block_decode,
     struct_decode,
+    write_bytes_padded,
+    write_int,
 )
 from pcapng.utils import unpack_timestamp_resolution
 
@@ -33,27 +38,91 @@ class Block(object):
     """Base class for blocks"""
 
     schema = []
+    readonly_fields = set()
+    __slots__ = [
+        # These are in addition to the above two properties
+        "magic_number",
+        "_raw",
+        "_decoded",
+    ]
 
-    def __init__(self, raw):
-        self._raw = raw
-        self._decoded = None
-
-    @classmethod
-    def from_context(cls, raw, ctx):
-        return cls(raw)  # no context needed by default
+    def __init__(self, **kwargs):
+        if "raw" in kwargs:
+            self._raw = kwargs["raw"]
+            self._decoded = None
+        else:
+            self._decoded = {}
+            for key, packed_type, default in self.schema:
+                if key == "options":
+                    self._decoded[key] = Options(
+                        schema=packed_type.options_schema, data={}, endianness="="
+                    )
+                else:
+                    self._decoded[key] = default
+            for aky, avl in kwargs.items():
+                if aky == "options":
+                    for oky, ovl in avl.items():
+                        self.options[oky] = ovl
+                else:
+                    self.__setattr__(aky, avl)
 
     def _decode(self):
-        return struct_decode(
-            self.schema, io.BytesIO(self._raw), endianness=self.section.endianness
-        )
+        """Decodes the raw data of this block into its fields"""
+        stream = io.BytesIO(self._raw)
+        self._decoded = block_decode(self, stream)
+        del self._raw
+
+    def write(self, outstream):
+        """Writes this block into the given output stream"""
+        encoded_block = io.BytesIO()
+        self._encode(encoded_block)
+        encoded_block = encoded_block.getvalue()
+        subblock_length = len(encoded_block)
+        block_length = 12 + subblock_length
+        if subblock_length % 4 != 0:
+            block_length += 4 - (subblock_length % 4)
+        write_int(self.magic_number, outstream, 32)
+        write_int(block_length, outstream, 32)
+        write_bytes_padded(outstream, encoded_block)
+        write_int(block_length, outstream, 32)
+
+    def _encode(self, outstream):
+        """Encodes the fields of this block into raw data"""
+        for name, field, default in self.schema:
+            field.encode(
+                getattr(self, name), outstream, endianness=self.section.endianness
+            )
 
     def __getattr__(self, name):
-        if self._decoded is None:
-            self._decoded = self._decode()
+        # __getattr__ is only called when getting an attribute that
+        # this object doesn't have.
         try:
+            if self._decoded is None:
+                self._decode()
             return self._decoded[name]
         except KeyError:
             raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        # __setattr__ is called for *any* attribute, real or not.
+        try:
+            # See it if it names an attribute we defined in our __slots__
+            return object.__setattr__(self, name, value)
+        except AttributeError:
+            # It's not an attribute.
+            # Proceed with our nice interface to the schema.
+            pass
+        if name in self.readonly_fields:
+            raise AttributeError(
+                "'{cls}' object property '{prop}' is read-only".format(
+                    prop=name, cls=self.__class__.__name__
+                )
+            )
+        if self._decoded is None:
+            self._decoded = {}
+            for key, packed_type, default in self.schema:
+                self._decoded[key] = None
+        self._decoded[name] = value
 
     def __repr__(self):
         args = []
@@ -69,13 +138,13 @@ class Block(object):
 
 
 class SectionMemberBlock(Block):
-    def __init__(self, raw, section):
-        super(SectionMemberBlock, self).__init__(raw)
-        self.section = section
+    """Block which must be a member of a section"""
 
-    @classmethod
-    def from_context(cls, raw, ctx):
-        return cls(raw, section=ctx.current_section)
+    __slots__ = ["section"]
+
+    def __init__(self, section, **kwargs):
+        super(SectionMemberBlock, self).__init__(**kwargs)
+        self.section = section
 
 
 def register_block(block):
@@ -86,35 +155,68 @@ def register_block(block):
 
 @register_block
 class SectionHeader(Block):
+    """
+    "The Section Header Block (SHB) is mandatory. It identifies the beginning
+    of a section of the capture file. The Section Header Block does not contain
+    data but it rather identifies a list of blocks (interfaces, packets) that
+    are logically correlated."
+    - pcapng spec, section 4.1. Other quoted citations are from this section
+    unless otherwise noted.
+    """
+
     magic_number = 0x0A0D0D0A
+    __slots__ = [
+        "endianness",
+        "_interfaces_id",
+        "interfaces",
+        "interface_stats",
+    ]
     schema = [
-        ("version_major", IntField(16, False)),
-        ("version_minor", IntField(16, False)),
-        ("section_length", IntField(64, True)),
+        ("version_major", IntField(16, False), 1),
+        ("version_minor", IntField(16, False), 0),
+        ("section_length", IntField(64, True), -1),
         (
             "options",
             OptionsField(
                 [
-                    (2, "shb_hardware", "string"),
-                    (3, "shb_os", "string"),
-                    (4, "shb_userappl", "string"),
+                    Option(2, "shb_hardware", "string"),
+                    Option(3, "shb_os", "string"),
+                    Option(4, "shb_userappl", "string"),
                 ]
             ),
+            None,
         ),
     ]
 
-    def __init__(self, raw, endianness):
-        self._raw = raw
-        self._decoded = None
+    def __init__(self, endianness="<", **kwargs):
+        super(SectionHeader, self).__init__(**kwargs)
         self.endianness = endianness
         self._interfaces_id = itertools.count(0)
         self.interfaces = {}
         self.interface_stats = {}
 
     def _decode(self):
-        return struct_decode(
+        self._decoded = struct_decode(
             self.schema, io.BytesIO(self._raw), endianness=self.endianness
         )
+        del self._raw
+
+    def _encode(self, outstream):
+        write_int(0x1A2B3C4D, outstream, 32, endianness=self.endianness)
+        super(SectionHeader, self)._encode(outstream)
+
+    def new_member(self, cls, **kwargs):
+        """Helper method to create a block that's a member of this section"""
+        assert issubclass(cls, SectionMemberBlock)
+        blk = cls(section=self, **kwargs)
+        # Some blocks (eg. SPB) don't have options
+        if any([x[0] == "options" for x in blk.schema]):
+            blk.options.endianness = self.endianness
+        if isinstance(blk, InterfaceDescription):
+            self.register_interface(blk)
+        elif isinstance(blk, InterfaceStatistics):
+            self.add_interface_stats(blk)
+        return blk
 
     def register_interface(self, interface):
         """Helper method to register an interface within this section"""
@@ -136,6 +238,11 @@ class SectionHeader(Block):
     def length(self):
         return self.section_length
 
+    # Block.decode() assumes all blocks have sections -- technically true...
+    @property
+    def section(self):
+        return self
+
     def __repr__(self):
         return (
             "<{name} version={version} endianness={endianness} "
@@ -151,30 +258,40 @@ class SectionHeader(Block):
 
 @register_block
 class InterfaceDescription(SectionMemberBlock):
+    """
+    "An Interface Description Block (IDB) is the container for information
+    describing an interface on which packet data is captured."
+    - pcapng spec, section 4.2. Other quoted citations are from this section
+    unless otherwise noted.
+    """
+
     magic_number = 0x00000001
+    __slots__ = []
     schema = [
-        ("link_type", IntField(16, False)),  # todo: enc/decode
-        ("reserved", RawBytes(2)),
-        ("snaplen", IntField(32, False)),
+        ("link_type", IntField(16, False), 0),  # todo: enc/decode
+        ("reserved", IntField(16, False), 0),
+        ("snaplen", IntField(32, False), 0),
         (
             "options",
             OptionsField(
                 [
-                    (2, "if_name", "string"),
-                    (3, "if_description", "string"),
-                    (4, "if_IPv4addr", "ipv4+mask"),
-                    (5, "if_IPv6addr", "ipv6+prefix"),
-                    (6, "if_MACaddr", "macaddr"),
-                    (7, "if_EUIaddr", "euiaddr"),
-                    (8, "if_speed", "u64"),
-                    (9, "if_tsresol"),  # Just keep the raw data
-                    (10, "if_tzone", "u32"),
-                    (11, "if_filter", "string"),
-                    (12, "if_os", "string"),
-                    (13, "if_fcslen", "u8"),
-                    (14, "if_tsoffset", "i64"),
+                    Option(2, "if_name", "string"),
+                    Option(3, "if_description", "string"),
+                    Option(4, "if_IPv4addr", "ipv4+mask", multiple=True),
+                    Option(5, "if_IPv6addr", "ipv6+prefix", multiple=True),
+                    Option(6, "if_MACaddr", "macaddr"),
+                    Option(7, "if_EUIaddr", "euiaddr"),
+                    Option(8, "if_speed", "u64"),
+                    Option(9, "if_tsresol"),  # Just keep the raw data
+                    Option(10, "if_tzone", "u32"),
+                    Option(11, "if_filter", "type+bytes"),
+                    Option(12, "if_os", "string"),
+                    Option(13, "if_fcslen", "u8"),
+                    Option(14, "if_tsoffset", "i64"),
+                    Option(15, "if_hardware", "string"),
                 ]
             ),
+            None,
         ),
     ]
 
@@ -217,6 +334,8 @@ class BlockWithTimestampMixin(object):
     of blocks that provide one.
     """
 
+    __slots__ = []
+
     @property
     def timestamp(self):
         # First, get the accuracy from the ts_resol option
@@ -232,114 +351,269 @@ class BlockWithTimestampMixin(object):
 
 
 class BlockWithInterfaceMixin(object):
+    """
+    Block mixin for blocks that have/require an interface.
+    This includes all packet blocks as well as InterfaceStatistics.
+    """
+
+    __slots__ = []
+
     @property
     def interface(self):
         # We need to get the correct interface from the section
         # by looking up the interface_id
         return self.section.interfaces[self.interface_id]
 
+    def write(self, outstream):
+        if len(self.section.interfaces) < 1:
+            strictness.problem(
+                "writing {cls} for section with no interfaces".format(
+                    cls=self.__class__.__name__
+                )
+            )
+            if strictness.should_fix():
+                # Only way to "fix" is to not write the block
+                return
+        super(BlockWithInterfaceMixin, self).write(outstream)
 
-class BasePacketBlock(
-    SectionMemberBlock, BlockWithInterfaceMixin, BlockWithTimestampMixin
-):
-    """Base class for the "EnhancedPacket" and "Packet" blocks"""
 
-    pass
+class BasePacketBlock(SectionMemberBlock, BlockWithInterfaceMixin):
+    """
+    Base class for blocks with packet data.
+    They must have these fields in their schema:
+
+    * ``packet_len`` is the original amount of data that was "on the wire"
+        (this can differ from ``captured_len``)
+    * ``packet_data`` is the actual binary packet data (of course)
+
+    This class makes the ``captured_len`` a read-only property returning
+    the current length of the packet data.
+    """
+
+    __slots__ = []
+    readonly_fields = set(("captured_len",))
+
+    @property
+    def captured_len(self):
+        return len(self.packet_data)
+
+    # Helper function. If the user hasn't explicitly set an original packet
+    # length, use the length of the captured packet data. And if they *have*
+    # set a length but it's smaller than the captured data, make it the same as
+    # the captured data length.
+    @property
+    def packet_len(self):
+        plen = self.__getattr__("packet_len") or 0  # this call prevents recursion
+        return plen or len(self.packet_data)
 
 
 @register_block
-class EnhancedPacket(BasePacketBlock):
+class EnhancedPacket(BasePacketBlock, BlockWithTimestampMixin):
+    """
+    "An Enhanced Packet Block (EPB) is the standard container for storing the
+    packets coming from the network."
+    - pcapng spec, section 4.3. Other quoted citations are from this section
+    unless otherwise noted.
+    """
+
     magic_number = 0x00000006
+    __slots__ = []
     schema = [
-        ("interface_id", IntField(32, False)),
-        ("timestamp_high", IntField(32, False)),
-        ("timestamp_low", IntField(32, False)),
-        ("packet_payload_info", PacketDataField()),
+        ("interface_id", IntField(32, False), 0),
+        ("timestamp_high", IntField(32, False), 0),
+        ("timestamp_low", IntField(32, False), 0),
+        ("captured_len", IntField(32, False), 0),
+        ("packet_len", IntField(32, False), 0),
+        ("packet_data", PacketBytes("captured_len"), b""),
         (
             "options",
             OptionsField(
                 [
-                    (2, "epb_flags"),  # todo: is this endianness dependent?
-                    (3, "epb_hash"),  # todo: process the hash value
-                    (4, "epb_dropcount", "u64"),
+                    Option(2, "epb_flags", "epb_flags"),
+                    Option(3, "epb_hash", "type+bytes", multiple=True),  # todo: process
+                    Option(4, "epb_dropcount", "u64"),
                 ]
             ),
+            None,
         ),
     ]
 
-    @property
-    def captured_len(self):
-        return self.packet_payload_info[0]
-
-    @property
-    def packet_len(self):
-        return self.packet_payload_info[1]
-
-    @property
-    def packet_data(self):
-        return self.packet_payload_info[2]
-
 
 @register_block
-class SimplePacket(SectionMemberBlock):
+class SimplePacket(BasePacketBlock):
+    """
+    "The Simple Packet Block (SPB) is a lightweight container for storing the
+    packets coming from the network."
+    - pcapng spec, section 4.4. Other quoted citations are from this section
+    unless otherwise noted.
+    """
+
     magic_number = 0x00000003
+    __slots__ = []
     schema = [
-        ("packet_simple_payload_info", SimplePacketDataField()),
+        # packet_len is NOT the captured length
+        ("packet_len", IntField(32, False), 0),
+        # We don't actually use this field; see _decode()/_encode()
+        ("packet_data", PacketBytes("captured_len"), b""),
     ]
 
-    @property
-    def packet_len(self):
-        return self.packet_simple_payload_info[1]
+    def __init__(self, **kwargs):
+        super(SimplePacket, self).__init__(**kwargs)
+        self.readonly_fields.add("interface_id")
+
+    readonly_fields = set(("captured_len", "interface_id"))
+
+    def _decode(self):
+        """Decodes the raw data of this block into its fields"""
+        stream = io.BytesIO(self._raw)
+        self._decoded = struct_decode(self.schema[:1], stream, self.section.endianness)
+        # Now we can get our ``captured_len`` property which is required
+        # to really know how much data we can load
+        rb = RawBytes(self.captured_len)
+        self._decoded["packet_data"] = rb.load(stream, self.section.endianness)
+        del self._raw
 
     @property
-    def packet_data(self):
-        return self.packet_simple_payload_info[2]
+    def interface_id(self):
+        """
+        "The Simple Packet Block does not contain the Interface ID field.
+        Therefore, it MUST be assumed that all the Simple Packet Blocks have
+        been captured on the interface previously specified in the first
+        Interface Description Block."
+        """
+        return 0
+
+    @property
+    def captured_len(self):
+        """
+        "...the SnapLen value MUST be used to determine the size of the Packet
+        Data field length."
+        """
+        snap_len = self.interface.snaplen
+        if snap_len == 0:  # unlimited
+            return self.packet_len
+        else:
+            return min(snap_len, self.packet_len)
+
+    def _encode(self, outstream):
+        fld_size = IntField(32, False)
+        fld_data = RawBytes(0)
+        if len(self.section.interfaces) > 1:
+            # Spec is a bit ambiguous here. Section 4.4 says "it MUST
+            # be assumed that all the Simple Packet Blocks have been captured
+            # on the interface previously specified in the first Interface
+            # Description Block." but later adds "A Simple Packet Block cannot
+            # be present in a Section that has more than one interface because
+            # of the impossibility to refer to the correct one (it does not
+            # contain any Interface ID field)." Why would it say "the first"
+            # IDB and not "the only" IDB if this was really forbidden?
+            strictness.problem(
+                "writing SimplePacket for section with multiple interfaces"
+            )
+            if strictness.should_fix():
+                # Can't fix this. The IDBs have already been written.
+                pass
+        snap_len = self.interface.snaplen
+        if snap_len > 0 and snap_len < self.captured_len:
+            # This isn't a strictness issue, it *will* break other readers
+            # if we write more bytes than the snaplen says to expect.
+            fld_size.encode(
+                self.packet_len, outstream, endianness=self.section.endianness
+            )
+            fld_data.encode(self.packet_data[:snap_len], outstream)
+        else:
+            fld_size.encode(
+                self.packet_len, outstream, endianness=self.section.endianness
+            )
+            fld_data.encode(self.packet_data, outstream)
 
 
 @register_block
-class Packet(BasePacketBlock):
+class ObsoletePacket(BasePacketBlock, BlockWithTimestampMixin):
+    """
+    "The Packet Block is obsolete, and MUST NOT be used in new files. [...] A
+    Packet Block was a container for storing packets coming from the network."
+    - pcapng spec, Appendix A. Other quoted citations are from this appendix
+    unless otherwise noted.
+    """
+
     magic_number = 0x00000002
+    __slots__ = []
     schema = [
-        ("interface_id", IntField(16, False)),
-        ("drops_count", IntField(16, False)),
-        ("timestamp_high", IntField(32, False)),
-        ("timestamp_low", IntField(32, False)),
-        ("packet_payload_info", PacketDataField()),
+        ("interface_id", IntField(16, False), 0),
+        ("drops_count", IntField(16, False), 0),
+        ("timestamp_high", IntField(32, False), 0),
+        ("timestamp_low", IntField(32, False), 0),
+        ("captured_len", IntField(32, False), 0),
+        ("packet_len", IntField(32, False), 0),
+        ("packet_data", PacketBytes("captured_len"), None),
         (
+            # The options have the same definitions as their epb_ equivalents
             "options",
             OptionsField(
-                [(2, "epb_flags", "u32"), (3, "epb_hash")]  # A flag!  # Variable size!
+                [
+                    Option(2, "pack_flags", "epb_flags"),
+                    Option(3, "pack_hash", "type+bytes", multiple=True),
+                ]
             ),
+            None,
         ),
     ]
 
-    @property
-    def captured_len(self):
-        return self.packet_payload_info[0]
+    def enhanced(self):
+        """Return an EnhancedPacket with this block's attributes."""
+        opts_dict = dict(self.options)
+        opts_dict["epb_dropcount"] = self.drops_count
+        for a in ("flags", "hash"):
+            try:
+                opts_dict["epb_" + a] = opts_dict.pop("pack_" + a)
+            except KeyError:
+                pass
+        return self.section.new_member(
+            EnhancedPacket,
+            interface_id=self.interface_id,
+            timestamp_high=self.timestamp_high,
+            timestamp_low=self.timestamp_low,
+            packet_len=self.packet_len,
+            packet_data=self.packet_data,
+            options=opts_dict,
+        )
 
-    @property
-    def packet_len(self):
-        return self.packet_payload_info[1]
-
-    @property
-    def packet_data(self):
-        return self.packet_payload_info[2]
+    def write(self, outstream):
+        strictness.problem("Packet Block is obsolete and must not be used")
+        if strictness.should_fix():
+            self.enhanced().write(outstream)
+        else:
+            super(ObsoletePacket, self).write(outstream)
 
 
 @register_block
 class NameResolution(SectionMemberBlock):
+    """
+    "The Name Resolution Block (NRB) is used to support the correlation of
+    numeric addresses (present in the captured packets) and their corresponding
+    canonical names [...]. Having the literal names saved in the file prevents
+    the need for performing name resolution at a later time, when the
+    association between names and addresses may be different from the one in
+    use at capture time."
+    - pcapng spec, section 4.5. Other quoted citations are from this section
+    unless otherwise noted.
+    """
+
     magic_number = 0x00000004
+    __slots__ = []
     schema = [
-        ("records", ListField(NameResolutionRecordField())),
+        ("records", ListField(NameResolutionRecordField()), []),
         (
             "options",
             OptionsField(
                 [
-                    (2, "ns_dnsname", "string"),
-                    (3, "ns_dnsIP4addr", "ipv4"),
-                    (4, "ns_dnsIP6addr", "ipv6"),
+                    Option(2, "ns_dnsname", "string"),
+                    Option(3, "ns_dnsIP4addr", "ipv4"),
+                    Option(4, "ns_dnsIP6addr", "ipv6"),
                 ]
             ),
+            None,
         ),
     ]
 
@@ -348,24 +622,34 @@ class NameResolution(SectionMemberBlock):
 class InterfaceStatistics(
     SectionMemberBlock, BlockWithTimestampMixin, BlockWithInterfaceMixin
 ):
+    """
+    "The Interface Statistics Block (ISB) contains the capture statistics for a
+    given interface [...]. The statistics are referred to the interface defined
+    in the current Section identified by the Interface ID field."
+    - pcapng spec, section 4.6. Other quoted citations are from this section
+    unless otherwise noted.
+    """
+
     magic_number = 0x00000005
+    __slots__ = []
     schema = [
-        ("interface_id", IntField(32, False)),
-        ("timestamp_high", IntField(32, False)),
-        ("timestamp_low", IntField(32, False)),
+        ("interface_id", IntField(32, False), 0),
+        ("timestamp_high", IntField(32, False), 0),
+        ("timestamp_low", IntField(32, False), 0),
         (
             "options",
             OptionsField(
                 [
-                    (2, "isb_starttime", "u64"),  # todo: consider resolution
-                    (3, "isb_endtime", "u64"),
-                    (4, "isb_ifrecv", "u64"),
-                    (5, "isb_ifdrop", "u64"),
-                    (6, "isb_filteraccept", "u64"),
-                    (7, "isb_osdrop", "u64"),
-                    (8, "isb_usrdeliv", "u64"),
+                    Option(2, "isb_starttime", "u64"),  # todo: consider resolution
+                    Option(3, "isb_endtime", "u64"),
+                    Option(4, "isb_ifrecv", "u64"),
+                    Option(5, "isb_ifdrop", "u64"),
+                    Option(6, "isb_filteraccept", "u64"),
+                    Option(7, "isb_osdrop", "u64"),
+                    Option(8, "isb_usrdeliv", "u64"),
                 ]
             ),
+            None,
         ),
     ]
 
@@ -377,6 +661,8 @@ class UnknownBlock(Block):
     Its block type and raw data will be stored directly with no further
     processing.
     """
+
+    __slots__ = ["block_type", "data"]
 
     def __init__(self, block_type, data):
         self.block_type = block_type

--- a/pcapng/exceptions.py
+++ b/pcapng/exceptions.py
@@ -4,6 +4,12 @@ class PcapngException(Exception):
     pass
 
 
+class PcapngWarning(Warning):
+    """Base for all the pcapng warnings"""
+
+    pass
+
+
 class PcapngLoadError(PcapngException):
     """Indicate an error while loading a pcapng file"""
 
@@ -14,6 +20,14 @@ class PcapngDumpError(PcapngException):
     """Indicate an error while writing a pcapng file"""
 
     pass
+
+
+class PcapngStrictnessError(PcapngException):
+    """Indicate a condition about poorly formed pcapng files"""
+
+
+class PcapngStrictnessWarning(PcapngWarning):
+    """Indicate a condition about poorly formed pcapng files"""
 
 
 class StreamEmpty(PcapngLoadError):  # End of stream

--- a/pcapng/flags.py
+++ b/pcapng/flags.py
@@ -3,8 +3,9 @@ Module to wrap an integer in bitwise flag/field accessors.
 """
 
 from collections import OrderedDict
+from collections.abc import Iterable
 
-from pcapng.utils import Iterable, namedtuple
+from pcapng._compat import namedtuple
 
 
 class FlagBase(object):
@@ -193,39 +194,3 @@ class FlagWord(object):
         except KeyError:
             raise AttributeError(name)
         return v.set(val)
-
-
-if __name__ == "__main__":
-    f = FlagWord(
-        [
-            FlagField("inout", FlagEnum, 2, ("NA", "inbound", "outbound")),
-            FlagField(
-                "casttype",
-                FlagEnum,
-                3,
-                ("NA", "unicast", "multicast", "broadcast", "promiscuous"),
-            ),
-            FlagField("fcslen", FlagUInt, 4),
-            FlagField("reserved", FlagUInt, 7),
-            FlagField("err_16", FlagBool),
-            FlagField("err_17", FlagBool),
-            FlagField("err_18", FlagBool),
-            FlagField("err_19", FlagBool),
-            FlagField("err_20", FlagBool),
-            FlagField("err_21", FlagBool),
-            FlagField("err_22", FlagBool),
-            FlagField("err_23", FlagBool),
-            FlagField("err_crc", FlagBool),
-            FlagField("err_long", FlagBool),
-            FlagField("err_short", FlagBool),
-            FlagField("err_frame_gap", FlagBool),
-            FlagField("err_frame_align", FlagBool),
-            FlagField("err_frame_delim", FlagBool),
-            FlagField("err_preamble", FlagBool),
-            FlagField("err_symbol", FlagBool),
-        ]
-    )
-
-    f.fcslen = 12
-    print(f)
-    print(int(f))

--- a/pcapng/flags.py
+++ b/pcapng/flags.py
@@ -1,0 +1,231 @@
+"""
+Module to wrap an integer in bitwise flag/field accessors.
+"""
+
+from collections import OrderedDict
+
+from pcapng.utils import Iterable, namedtuple
+
+
+class FlagBase(object):
+    """\
+    Base class for flag types to be used in a Flags object.
+    Handles the bitwise math so subclasses don't have to worry about it.
+    """
+
+    __slots__ = [
+        "owner",
+        "offset",
+        "size",
+        "extra",
+        "mask",
+    ]
+
+    def __init__(self, owner, offset, size, extra=None):
+        if size < 1:
+            raise TypeError("Flag must be at least 1 bit wide")
+        if size > owner._nbits:
+            raise TypeError("Flag must fit into owner size")
+        self.owner = owner
+        self.offset = offset
+        self.size = size
+        self.extra = extra
+        self.mask = ((1 << self.size) - 1) << self.offset
+
+    def get_bits(self):
+        return (self.owner._value & self.mask) >> self.offset
+
+    def set_bits(self, val):
+        val &= (1 << self.size) - 1
+        self.owner._value &= ~self.mask
+        self.owner._value |= val << self.offset
+
+
+class FlagBool(FlagBase):
+    """Object representing a single boolean flag"""
+
+    def __init__(self, owner, offset, size, extra=None):
+        if size != 1:
+            raise TypeError(
+                "{cls} can only be 1 bit in size".format(cls=self.__class__.__name__)
+            )
+        super(FlagBool, self).__init__(owner, offset, size)
+
+    def get(self):
+        return bool(self.get_bits())
+
+    def set(self, val):
+        self.set_bits(int(bool(val)))
+
+
+class FlagUInt(FlagBase):
+    """\
+    Object representing an unsigned integer of the given size stored in
+    a larger bitfield
+    """
+
+    def get(self):
+        return self.get_bits()
+
+    def set(self, val):
+        self.set_bits(val)
+
+
+class FlagEnum(FlagBase):
+    """\
+    Object representing a range of values stored in part of a larger
+    bitfield
+    """
+
+    def __init__(self, owner, offset, size, extra=None):
+        if not isinstance(extra, Iterable):
+            raise TypeError(
+                "{cls} needs an iterable of values".format(cls=self.__class__.__name__)
+            )
+        extra = list(extra)
+        if len(extra) > 2 ** size:
+            raise TypeError(
+                "{cls} iterable has too many values (got {got}, "
+                + "{size} bits only address {max})".format(
+                    cls=self.__class__.__name__,
+                    got=len(extra),
+                    size=size,
+                    max=2 ** size,
+                )
+            )
+
+        super(FlagEnum, self).__init__(owner, offset, size, extra)
+
+    def get(self):
+        val = self.get_bits()
+        try:
+            return self.extra[val]
+        except IndexError:
+            return "[invalid value]"
+
+    def set(self, val):
+        if val in self.extra:
+            self.set_bits(self.extra.index(val))
+        elif isinstance(val, int):
+            self.set_bits(val)
+        else:
+            raise TypeError(
+                "Invalid value {val} for {cls}".format(
+                    val=val, cls=self.__class__.__name__
+                )
+            )
+
+
+# Class representing a single flag schema for FlagWord.
+# 'nbits' defaults to 1, and 'extra' defaults to None.
+FlagField = namedtuple(
+    "FlagField", ("name", "ftype", "nbits", "extra"), defaults=(1, None)
+)
+
+
+class FlagWord(object):
+    """\
+    Class to wrap an integer in bitwise flag/field accessors.
+    """
+
+    __slots__ = [
+        "_nbits",
+        "_value",
+        "_schema",
+    ]
+
+    def __init__(self, schema, nbits=32, initial=0):
+        """
+        :param schema:
+            A list of FlagField objects representing the values to be packed
+            into this object, in order from LSB to MSB of the underlying int
+
+        :param nbits:
+            An integer representing the total number of bits used for flags
+
+        :param initial:
+            The initial integer value of the flags field
+        """
+
+        self._nbits = nbits
+        self._value = initial
+        self._schema = OrderedDict()
+
+        tot_bits = sum([item.nbits for item in schema])
+        if tot_bits > nbits:
+            raise TypeError(
+                "Too many fields for {nbits}-bit field "
+                + "(schema defines {tot} bits)".format(nbits=nbits, tot=tot_bits)
+            )
+
+        bitn = 0
+        for item in schema:
+            if not isinstance(item, FlagField):
+                raise TypeError("Schema must be composed of FlagField objects")
+            if not issubclass(item.ftype, FlagBase):
+                raise TypeError("Expected FlagBase, got {}".format(item.ftype))
+            self._schema[item.name] = item.ftype(self, bitn, item.nbits, item.extra)
+            bitn += item.nbits
+
+    def __int__(self):
+        return self._value
+
+    def __repr__(self):
+        rv = "<{0} (value={1})".format(self.__class__.__name__, self._value)
+        for k, v in self._schema.items():
+            rv += " {0}={1}".format(k, v.get())
+        return rv + ">"
+
+    def __getattr__(self, name):
+        try:
+            v = self._schema[name]
+        except KeyError:
+            raise AttributeError(name)
+        return v.get()
+
+    def __setattr__(self, name, val):
+        try:
+            return object.__setattr__(self, name, val)
+        except AttributeError:
+            pass
+        try:
+            v = self._schema[name]
+        except KeyError:
+            raise AttributeError(name)
+        return v.set(val)
+
+
+if __name__ == "__main__":
+    f = FlagWord(
+        [
+            FlagField("inout", FlagEnum, 2, ("NA", "inbound", "outbound")),
+            FlagField(
+                "casttype",
+                FlagEnum,
+                3,
+                ("NA", "unicast", "multicast", "broadcast", "promiscuous"),
+            ),
+            FlagField("fcslen", FlagUInt, 4),
+            FlagField("reserved", FlagUInt, 7),
+            FlagField("err_16", FlagBool),
+            FlagField("err_17", FlagBool),
+            FlagField("err_18", FlagBool),
+            FlagField("err_19", FlagBool),
+            FlagField("err_20", FlagBool),
+            FlagField("err_21", FlagBool),
+            FlagField("err_22", FlagBool),
+            FlagField("err_23", FlagBool),
+            FlagField("err_crc", FlagBool),
+            FlagField("err_long", FlagBool),
+            FlagField("err_short", FlagBool),
+            FlagField("err_frame_gap", FlagBool),
+            FlagField("err_frame_align", FlagBool),
+            FlagField("err_frame_delim", FlagBool),
+            FlagField("err_preamble", FlagBool),
+            FlagField("err_symbol", FlagBool),
+        ]
+    )
+
+    f.fcslen = 12
+    print(f)
+    print(int(f))

--- a/pcapng/strictness.py
+++ b/pcapng/strictness.py
@@ -1,0 +1,34 @@
+"""
+Module for alerting the user when attempting to do things with pcapng that
+aren't strictly valid.
+"""
+
+import warnings
+
+from pcapng.exceptions import PcapngStrictnessError, PcapngStrictnessWarning
+
+STRICTNESS_NONE = 0  # No warnings, do what you want
+STRICTNESS_WARN = 1  # Do what you want, but warn of potential issues
+STRICTNESS_FIX = 2  # Warn of potential issues, fix *if possible*
+STRICTNESS_FORBID = 3  # raise exception on potential issues
+
+strictness = STRICTNESS_FORBID
+
+
+def problem(msg):
+    "Warn or raise an exception with the given message."
+    if strictness == STRICTNESS_FORBID:
+        raise PcapngStrictnessError(msg)
+    elif strictness in (STRICTNESS_WARN, STRICTNESS_FIX):
+        warnings.warn(PcapngStrictnessWarning(msg))
+
+
+def warn(msg):
+    "Show a warning with the given message."
+    if strictness > STRICTNESS_NONE:
+        warnings.warn(PcapngStrictnessWarning(msg))
+
+
+def should_fix():
+    "Helper function for showing code used to fix questionable pcapng data."
+    return strictness == STRICTNESS_FIX

--- a/pcapng/strictness.py
+++ b/pcapng/strictness.py
@@ -4,31 +4,41 @@ aren't strictly valid.
 """
 
 import warnings
+from enum import Enum
 
 from pcapng.exceptions import PcapngStrictnessError, PcapngStrictnessWarning
 
-STRICTNESS_NONE = 0  # No warnings, do what you want
-STRICTNESS_WARN = 1  # Do what you want, but warn of potential issues
-STRICTNESS_FIX = 2  # Warn of potential issues, fix *if possible*
-STRICTNESS_FORBID = 3  # raise exception on potential issues
 
-strictness = STRICTNESS_FORBID
+class Strictness(Enum):
+    NONE = 0  # No warnings, do what you want
+    WARN = 1  # Do what you want, but warn of potential issues
+    FIX = 2  # Warn of potential issues, fix *if possible*
+    FORBID = 3  # raise exception on potential issues
+
+
+strict_level = Strictness.FORBID
+
+
+def set_strictness(level):
+    assert type(level) is Strictness
+    global strict_level
+    strict_level = level
 
 
 def problem(msg):
     "Warn or raise an exception with the given message."
-    if strictness == STRICTNESS_FORBID:
+    if strict_level == Strictness.FORBID:
         raise PcapngStrictnessError(msg)
-    elif strictness in (STRICTNESS_WARN, STRICTNESS_FIX):
+    elif strict_level in (Strictness.WARN, Strictness.FIX):
         warnings.warn(PcapngStrictnessWarning(msg))
 
 
 def warn(msg):
     "Show a warning with the given message."
-    if strictness > STRICTNESS_NONE:
+    if strict_level > Strictness.NONE:
         warnings.warn(PcapngStrictnessWarning(msg))
 
 
 def should_fix():
     "Helper function for showing code used to fix questionable pcapng data."
-    return strictness == STRICTNESS_FIX
+    return strict_level == Strictness.FIX

--- a/pcapng/structs.py
+++ b/pcapng/structs.py
@@ -3,20 +3,31 @@ Module providing facilities for handling struct-like data.
 """
 
 import abc
-import io
 import struct
 import warnings
 
-import six
-
-from pcapng.exceptions import BadMagic, CorruptedFile, StreamEmpty, TruncatedFile
-from pcapng.utils import unpack_euiaddr, unpack_ipv4, unpack_ipv6, unpack_macaddr
-
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
-
+from pcapng import strictness as strictness
+from pcapng.exceptions import (
+    BadMagic,
+    CorruptedFile,
+    PcapngLoadError,
+    StreamEmpty,
+    TruncatedFile,
+)
+from pcapng.flags import FlagBool, FlagEnum, FlagField, FlagUInt, FlagWord
+from pcapng.utils import (
+    Iterable,
+    Mapping,
+    namedtuple,
+    pack_euiaddr,
+    pack_ipv4,
+    pack_ipv6,
+    pack_macaddr,
+    unpack_euiaddr,
+    unpack_ipv4,
+    unpack_ipv6,
+    unpack_macaddr,
+)
 
 SECTION_HEADER_MAGIC = 0x0A0D0D0A
 BYTE_ORDER_MAGIC = 0x1A2B3C4D
@@ -38,6 +49,10 @@ TYPE_IPV6 = "ipv6"
 TYPE_IPV6_PREFIX = "ipv6+prefix"
 TYPE_MACADDR = "macaddr"
 TYPE_EUIADDR = "euiaddr"
+TYPE_TYPE_BYTES = "type+bytes"
+TYPE_EPBFLAGS = "epb_flags"
+TYPE_OPT_CUSTOM_STR = "opt_custom_str"
+TYPE_OPT_CUSTOM_BYTES = "opt_custom_bytes"
 
 TYPE_U8 = "u8"  # Unsigned integer, 8 bits
 TYPE_U16 = "u16"
@@ -47,6 +62,21 @@ TYPE_I8 = "i8"  # Signed integer, 8 bits
 TYPE_I16 = "i16"
 TYPE_I32 = "i32"
 TYPE_I64 = "i64"
+
+_numeric_types = {
+    TYPE_U8: "B",
+    TYPE_I8: "b",
+    TYPE_U16: "H",
+    TYPE_I16: "h",
+    TYPE_U32: "I",
+    TYPE_I32: "i",
+    TYPE_U64: "Q",
+    TYPE_I64: "q",
+}
+
+NRB_RECORD_END = 0
+NRB_RECORD_IPv4 = 1
+NRB_RECORD_IPv6 = 2
 
 
 def read_int(stream, size, signed=False, endianness="="):
@@ -71,6 +101,29 @@ def read_int(stream, size, signed=False, endianness="="):
     size_bytes = size // 8
     data = read_bytes(stream, size_bytes)
     return struct.unpack(fmt, data)[0]
+
+
+def write_int(number, stream, size, signed=False, endianness="="):
+    """
+    Write (and encode) an integer number to a binary stream.
+
+    :param number: the integer number to write
+    :param stream: an object providing a ``write()`` method
+    :param size: the size, in bits, of the number to be written.
+        Supported sizes are: 8, 16, 32 and 64 bits.
+    :param signed: Whether a signed or unsigned number is required.
+        Defaults to ``False`` (unsigned int).
+    :param endianness: specify the endianness to use to encode the number,
+        in the same format used by Python :py:mod:`struct` module.
+        Defaults to '=' (native endianness). '!' means "network" endianness
+        (big endian), '<' little endian, '>' big endian.
+
+    """
+    fmt = INT_FORMATS.get(size)
+    fmt = fmt.lower() if signed else fmt.upper()
+    assert endianness in "<>!="
+    fmt = endianness + fmt
+    write_bytes(stream, struct.pack(fmt, number))
 
 
 def read_section_header(stream):
@@ -178,6 +231,16 @@ def read_bytes(stream, size):
     return data
 
 
+def write_bytes(stream, data):
+    """
+    Write the given amount of raw bytes to a stream.
+
+    :param stream: the stream into which to write data
+    :param data: the data to write
+    """
+    stream.write(data)
+
+
 def read_bytes_padded(stream, size, pad_block_size=4):
     """
     Read the given amount of bytes from a stream, plus read and discard
@@ -202,13 +265,34 @@ def read_bytes_padded(stream, size, pad_block_size=4):
     return data
 
 
+def write_bytes_padded(stream, data, pad_block_size=4):
+    """
+    Read the given amount of bytes from a stream, plus read and discard
+    any necessary extra byte to align up to the pad_block_size-sized
+    next block.
+
+    :param stream: the stream from which to read data
+    :param size: the size to read, in bytes
+    :returns: the read data
+    :raises: :py:exc:`~pcapng.exceptions.StreamEmpty` if zero bytes were read
+    :raises: :py:exc:`~pcapng.exceptions.TruncatedFile` if 0 < bytes < size
+        were read
+    """
+
+    write_bytes(stream, data)
+    padding = (pad_block_size - (len(data) % pad_block_size)) % pad_block_size
+    if padding > 0:
+        write_bytes(stream, bytes([0] * padding))
+
+
 class StructField(object):
     """Abstract base class for struct fields"""
 
     __metaclass__ = abc.ABCMeta
+    __slots__ = []
 
     @abc.abstractmethod
-    def load(self, stream, endianness):
+    def load(self, stream, endianness, seen=None):
         pass
 
     def __repr__(self):
@@ -216,6 +300,9 @@ class StructField(object):
 
     def __unicode__(self):
         return self.__repr__().encode("UTF-8")
+
+    def encode_finish(self, stream, endianness):
+        pass
 
 
 class RawBytes(StructField):
@@ -225,11 +312,16 @@ class RawBytes(StructField):
     :param size: field size, in bytes
     """
 
+    __slots__ = ["size"]
+
     def __init__(self, size):
         self.size = size  # in bytes!
 
-    def load(self, stream, endianness):
-        return read_bytes(stream, self.size)
+    def load(self, stream, endianness, seen=None):
+        return read_bytes_padded(stream, self.size)
+
+    def encode(self, value, stream, endianness=None):
+        write_bytes_padded(stream, value)
 
     def __repr__(self):
         return "{0}(size={1!r})".format(self.__class__.__name__, self.size)
@@ -245,13 +337,20 @@ class IntField(StructField):
         integer. Defaults to False (unsigned)
     """
 
+    __slots__ = ["size", "signed"]
+
     def __init__(self, size, signed=False):
         self.size = size  # in bits!
         self.signed = signed
 
-    def load(self, stream, endianness):
+    def load(self, stream, endianness, seen=None):
         number = read_int(stream, self.size, signed=self.signed, endianness=endianness)
         return number
+
+    def encode(self, number, stream, endianness):
+        if not isinstance(number, int):
+            raise TypeError("'{}' is not numeric".format(number))
+        write_int(number, stream, self.size, signed=self.signed, endianness=endianness)
 
     def __repr__(self):
         return "{0}(size={1!r}, signed={2!r})".format(
@@ -268,18 +367,23 @@ class OptionsField(StructField):
         constructor.
     """
 
+    __slots__ = ["options_schema"]
+
     def __init__(self, options_schema):
         self.options_schema = options_schema
 
-    def load(self, stream, endianness):
+    def load(self, stream, endianness, seen=None):
         options = read_options(stream, endianness)
         return Options(schema=self.options_schema, data=options, endianness=endianness)
+
+    def encode(self, options, stream, endianness):
+        write_options(stream, options)
 
     def __repr__(self):
         return "{0}({1!r})".format(self.__class__.__name__, self.options_schema)
 
 
-class PacketDataField(StructField):
+class PacketBytes(StructField):
     """
     Field containing some "packet data", used in the Packet
     and EnhancedPacket blocks.
@@ -291,27 +395,32 @@ class PacketDataField(StructField):
     - packet data (captured_len-sized binary data)
     """
 
-    def load(self, stream, endianness):
-        captured_len = read_int(stream, 32, False, endianness)
-        packet_len = read_int(stream, 32, False, endianness)
-        packet_data = read_bytes_padded(stream, captured_len)
-        return captured_len, packet_len, packet_data
+    __slots__ = ["dependency"]
 
+    def __init__(self, len_field):
+        self.dependency = len_field
 
-class SimplePacketDataField(StructField):
-    """
-    Field containing packet data from a SimplePacket object.
+    def load(self, stream, endianness, seen=[]):
+        try:
+            length = seen[self.dependency]
+        except TypeError:
+            raise PcapngLoadError(
+                "PacketBytes dependent on field '{0}' which wasn't passed".format(
+                    self.dependency
+                )
+            )
+        except KeyError:
+            raise PcapngLoadError(
+                "PacketBytes dependent on field '{0}' which was never found".format(
+                    self.dependency
+                )
+            )
+        return read_bytes_padded(stream, length)
 
-    The packet data is represented by two fields (returned as a tuple):
-
-    - packet_len (uint32)
-    - packet_data (packet_len-sized binary data)
-    """
-
-    def load(self, stream, endianness):
-        packet_len = read_int(stream, 32, False, endianness)
-        packet_data = read_bytes_padded(stream, packet_len)
-        return packet_len, packet_data
+    def encode(self, packet, stream, endianness=None):
+        if not packet:
+            raise ValueError("Packet invalid")
+        write_bytes_padded(stream, packet)
 
 
 class ListField(StructField):
@@ -331,10 +440,12 @@ class ListField(StructField):
         used to read values from the stream.
     """
 
+    __slots__ = ["subfield"]
+
     def __init__(self, subfield):
         self.subfield = subfield
 
-    def load(self, stream, endianness):
+    def load(self, stream, endianness, seen=None):
         return list(self._iter_load(stream, endianness))
 
     def _iter_load(self, stream, endianness):
@@ -343,6 +454,11 @@ class ListField(StructField):
                 yield self.subfield.load(stream, endianness)
             except StreamEmpty:
                 return
+
+    def encode(self, list_data, stream, endianness):
+        for rec in list_data:
+            self.subfield.encode(rec, stream, endianness)
+        self.subfield.encode_finish(stream, endianness)
 
     def __repr__(self):
         return "{0}({1!r})".format(self.__class__.__name__, self.subfield)
@@ -366,33 +482,61 @@ class NameResolutionRecordField(StructField):
     - ``0x02`` - ipv6 address resolution
 
     In both cases, the payload is composed of a valid address in the
-    selected IP version, followed by domain name up to the field end.
+    selected IP version, followed by null-separated/terminated domain names.
     """
 
-    def load(self, stream, endianness):
+    __slots__ = []
+
+    def load(self, stream, endianness, seen=None):
         record_type = read_int(stream, 16, False, endianness)
         record_length = read_int(stream, 16, False, endianness)
 
-        if record_type == 0:
+        if record_type == NRB_RECORD_END:
             raise StreamEmpty("End marker reached")
 
         data = read_bytes_padded(stream, record_length)
 
-        if record_type == 1:  # IPv4
+        if record_type == NRB_RECORD_IPv4:
             return {
                 "type": record_type,
-                "address": data[:4],
-                "name": data[4:],
+                "address": unpack_ipv4(data[:4]),
+                "names": [x.decode() for x in data[4:].split(b"\x00")],
             }
 
-        if record_type == 2:  # IPv6
+        if record_type == NRB_RECORD_IPv6:
             return {
                 "type": record_type,
-                "address": data[:16],
-                "name": data[16:],
+                "address": unpack_ipv6(data[:16]),
+                "names": [x.decode() for x in data[16:].split(b"\x00")],
             }
 
         return {"type": record_type, "raw": data}
+
+    def encode(self, d, stream, endianness):
+        write_int(d["type"], stream, 16, endianness=endianness)
+
+        if d["type"] == NRB_RECORD_END:
+            write_int(0, stream, 16, endianness=endianness)
+
+        elif d["type"] == NRB_RECORD_IPv4:
+            raw = pack_ipv4(d["address"])
+            raw += (b"\x00".join([s.encode() for s in d["names"]])) + b"\x00"
+            write_int(len(raw), stream, 16, endianness=endianness)
+            write_bytes_padded(stream, raw)
+
+        elif d["type"] == NRB_RECORD_IPv6:
+            raw = pack_ipv6(d["address"])
+            raw += (b"\x00".join([s.encode() for s in d["names"]])) + b"\x00"
+            write_int(len(raw), stream, 16, endianness=endianness)
+            write_bytes_padded(stream, raw)
+
+        else:
+            write_int(len(d["raw"]), stream, 16, endianness=endianness)
+            write_bytes_padded(stream, d["raw"])
+
+    def encode_finish(self, stream, endianness):
+        write_int(NRB_RECORD_END, stream, 16, endianness=endianness)
+        write_int(0, stream, 16, endianness=endianness)
 
 
 def read_options(stream, endianness):
@@ -427,6 +571,87 @@ def read_options(stream, endianness):
     return list(_iter_read_options(stream, endianness))
 
 
+def write_options(stream, options):
+    """
+    Each option is composed by:
+
+    - option_code (uint16)
+    - value_length (uint16)
+    - value (value_length-sized binary data)
+
+    The end marker is simply an option with code ``0x0000``, length 0,
+    and no payload
+    """
+
+    if not options:
+        # Options are optional; if there are none we don't need opt_endofopt
+        return
+
+    for key in options:
+        code = options._field_names[key]
+        values = options.get_all_raw(key)
+        if len(values) > 1 and not options.schema[code].multiple:
+            strictness.problem(
+                "writing repeated option {} '{}' not permitted by pcapng spec".format(
+                    code, options._get_name_alias(code)
+                )
+            )
+            if strictness.should_fix():
+                values = values[:1]
+        for value in values:
+            write_int(code, stream, 16, False, options.endianness)
+            write_int(len(value), stream, 16, False, options.endianness)
+            write_bytes_padded(stream, value)
+    # Write the end marker
+    write_int(0, stream, 32, False, options.endianness)
+
+
+class EPBFlags(FlagWord):
+    """Class representing the epb_flags option on an EPB"""
+
+    __slots__ = []
+
+    def __init__(self, val=0):
+        super(EPBFlags, self).__init__(
+            [
+                FlagField("inout", FlagEnum, 2, ("NA", "inbound", "outbound")),
+                FlagField(
+                    "casttype",
+                    FlagEnum,
+                    3,
+                    ("NA", "unicast", "multicast", "broadcast", "promiscuous"),
+                ),
+                FlagField("fcslen", FlagUInt, 4),
+                FlagField("reserved", FlagUInt, 7),
+                FlagField("err_16", FlagBool),
+                FlagField("err_17", FlagBool),
+                FlagField("err_18", FlagBool),
+                FlagField("err_19", FlagBool),
+                FlagField("err_20", FlagBool),
+                FlagField("err_21", FlagBool),
+                FlagField("err_22", FlagBool),
+                FlagField("err_23", FlagBool),
+                FlagField("err_crc", FlagBool),
+                FlagField("err_long", FlagBool),
+                FlagField("err_short", FlagBool),
+                FlagField("err_frame_gap", FlagBool),
+                FlagField("err_frame_align", FlagBool),
+                FlagField("err_frame_delim", FlagBool),
+                FlagField("err_preamble", FlagBool),
+                FlagField("err_symbol", FlagBool),
+            ],
+            nbits=32,
+            initial=val,
+        )
+
+
+# Class representing a single option schema for Options.
+# require code and name; by default, empty ftype, forbid multiples
+Option = namedtuple(
+    "Option", ("code", "name", "ftype", "multiple"), defaults=(None, False)
+)
+
+
 class Options(Mapping):
     """
     Wrapper object used to easily access the contents of an "options"
@@ -444,9 +669,7 @@ class Options(Mapping):
         to a dictionary).
 
     :param schema:
-        Definition of the known options: a list of 2- or 3-tuples
-        (the third argument is optional) representing, respectively,
-        the numeric option code, the option name and the value type.
+        Definition of the known options: a list of Option objects.
 
         The following value types are currently supported:
 
@@ -458,6 +681,12 @@ class Options(Mapping):
         - ``ipv6+prefix``: an ipv6 address followed by prefix length [17 bytes]
         - ``macaddr``: a mac address [6 bytes]
         - ``euiaddr``: a eui address [8 bytes]
+        - ``epb_flags``: 32-bit bitmask as per pcapng spec section 4.3.1
+        - ``type+bytes``: field where the first byte is a type, and
+          the remainder is bytes
+        - ``opt_custom_str`` and ``opt_custom_bytes``: 4 bytes of Private
+          Enterprise Number, followed by str or bytes (see pcapng spec,
+          section 3.5.1)
 
     :param data:
         Initial data for the options. A list of two-tuples: ``(code, value)``.
@@ -470,15 +699,34 @@ class Options(Mapping):
         Required in order to load numeric fields.
     """
 
+    __slots__ = [
+        "schema",
+        "_field_names",
+        "data",
+        "endianness",
+    ]
+
     def __init__(self, schema, data, endianness):
-        self.schema = {}  # Schema of option fields: {<code>: {..def..}}
+        self.schema = {}  # Schema of option fields: {<code>: Option(...)}
         self._field_names = {}  # Map names to codes
-        self.raw_data = {}  # List of (code, value) tuples
+        self.data = {}  # List of (code, value) tuples
         self.endianness = endianness  # one of '<>!='
 
         # This is the default schema, common to all objects
-        self._update_schema([(0, "opt_endofopt"), (1, "opt_comment", TYPE_STRING)])
-        self._update_schema(schema)
+        for item in [
+            Option(0, "opt_endofopt"),
+            Option(1, "opt_comment", TYPE_STRING, multiple=True),
+            # The spec calls all these next options ``opt_custom`` --
+            # I've renamed them here so they can be told apart
+            Option(2988, "custom_str_safe", TYPE_OPT_CUSTOM_STR, multiple=True),
+            Option(2989, "custom_bytes_safe", TYPE_OPT_CUSTOM_BYTES, multiple=True),
+            Option(19372, "custom_str", TYPE_OPT_CUSTOM_STR, multiple=True),
+            Option(19373, "custom_bytes", TYPE_OPT_CUSTOM_BYTES, multiple=True),
+        ] + list(schema):
+            if not isinstance(item, Option):
+                raise TypeError("expected option, got '{}'".format(item))
+            self.schema[item.code] = item
+        self._field_names = {x.name: x.code for x in self.schema.values()}
 
         # Update raw data with current values
         self._update_data(data)
@@ -486,26 +734,50 @@ class Options(Mapping):
     # -------------------- Nice interface :) --------------------
 
     def __getitem__(self, name):
-        return self._get_converted(name)
+        code = self._resolve_name(name)
+        return self.data[code][0]
 
     def __len__(self):
-        return len(self.raw_data)
+        return len(self.data)
 
     def __iter__(self):
-        for key in self.raw_data:
+        for key in self.data:
             yield self._get_name_alias(key)
+
+    def __setitem__(self, name, value):
+        # This also gets called for ``block.options[name] += value``
+        # as if ``block.options[name] = block.options[name] + value``
+        # which means that, if value is a string, each character gets added
+        # separately. Workaround: wrap the string in [ ], or use ``add()``
+        code = self._resolve_name(name)
+        if isinstance(value, Iterable) and not isinstance(
+            value, (str, bytes, bytearray)
+        ):
+            # We're being assigned a list/iterable, use its values for our list
+            self.data[code] = list(value)
+            self._check_multiples(code)
+        else:
+            # We're being assigned a single value, store as a one-item list
+            self.data[code] = [value]
+
+    def __delitem__(self, name):
+        code = self._resolve_name(name)
+        del self.data[code]
 
     def get_all(self, name):
         """Get all values for the given option"""
-        return self._get_all_converted(name)
+        code = self._resolve_name(name)
+        return self.data[code]
 
     def get_raw(self, name):
         """Get raw value for the given option"""
-        return self._get_raw(name)
+        code = self._resolve_name(name)
+        return self._encode_value(self.data[code][0], self.schema[code].ftype)
 
     def get_all_raw(self, name):
         """Get all raw values for the given option"""
-        return self._get_all_raw(name)
+        code = self._resolve_name(name)
+        return [self._encode_value(x, self.schema[code].ftype) for x in self.data[code]]
 
     def iter_all_items(self):
         """
@@ -515,6 +787,14 @@ class Options(Mapping):
         for key in self:
             yield key, self.get_all(key)
 
+    def add(self, name, value):
+        """Add a value to the given-named option"""
+        code = self._resolve_name(name)
+        if code not in self.data:
+            self.data[code] = []
+        self.data[code].append(value)
+        self._check_multiples(code)
+
     def __repr__(self):
         args = dict(self.iter_all_items())
         name = self.__class__.__name__
@@ -522,77 +802,64 @@ class Options(Mapping):
 
     # -------------------- Internal methods --------------------
 
-    def _update_schema(self, schema):
-        def _make_option(code, name, ftype=TYPE_BYTES):
-            return code, name, ftype
-
-        for item in schema:
-            try:
-                code, name, ftype = _make_option(*item)
-
-            except TypeError:
-                # Better error message
-                raise TypeError("Options schema item must be a 2- or 3-tuple")
-
-            self.schema[code] = {"name": name, "ftype": ftype}
-            self._field_names[name] = code
-
     def _update_data(self, data):
         if data is None:
             return
 
         for code, value in data:
-            if code not in self.raw_data:
-                self.raw_data[code] = []
-            self.raw_data[code].append(value)
+            if code not in self.data:
+                self.data[code] = []
+            self.data[code].append(self._decode(code, value))
+            if len(self.data[code]) > 1 and not self.schema[code].multiple:
+                try:
+                    name = "{} '{}'".format(code, self.schema[code].name)
+                except KeyError:
+                    name = "{} (unknown)".format(code)
+                # This code gets called when reading a file. We don't want
+                # to potentially abort in this case, just warn
+                strictness.warn(
+                    "repeated option {} not permitted by pcapng spec".format(name)
+                )
+
+    def _check_multiples(self, code):
+        """Check if a non-repeatable option is repeated"""
+        if len(self.data[code]) > 1 and not self.schema[code].multiple:
+            strictness.problem(
+                "repeated option {} '{}' not permitted by pcapng spec".format(
+                    code, self._get_name_alias(code)
+                )
+            )
+            if strictness.should_fix():
+                self.data[code] = self.data[code][:1]
 
     def _resolve_name(self, name):
-        return self._field_names.get(name) or name
+        code = self._field_names.get(name, name)
+        if code == 0:
+            # opt_endofopt is special and should never be touched by the user
+            raise KeyError(name)
+        return code
 
     def _get_name_alias(self, code):
         if code in self.schema:
-            return self.schema[code]["name"]
+            return self.schema[code].name
         return code
 
-    def _get_raw(self, name):
-        _name = self._resolve_name(name)
-        try:
-            return self.raw_data[_name][0]
-        except KeyError:
-            raise KeyError(name)
-
-    def _get_all_raw(self, name):
-        _name = self._resolve_name(name)
-        try:
-            return list(self.raw_data[_name])
-        except KeyError:
-            raise KeyError(name)
-
-    def _get_converted(self, name):
-        value = self._get_raw(name)
-        return self._convert(name, value)
-
-    def _get_all_converted(self, name):
-        value = self._get_all_raw(name)
-        return self._convert_all(name, value)
-
-    def _convert(self, code, value):
+    def _decode(self, code, value):
         code = self._resolve_name(code)
         if code in self.schema:
-            return self._convert_value(value, self.schema[code]["ftype"])
+            return self._decode_value(value, self.schema[code].ftype)
         return value
 
-    def _convert_all(self, code, values):
+    def _decode_all(self, code, values):
         code = self._resolve_name(code)
         if code in self.schema:
             return [
-                self._convert_value(value, self.schema[code]["ftype"])
-                for value in values
+                self._decode_value(value, self.schema[code].ftype) for value in values
             ]
         return values
 
-    def _convert_value(self, value, ftype):
-        assert isinstance(value, six.binary_type)
+    def _decode_value(self, value, ftype):
+        assert isinstance(value, (bytes, bytearray))
 
         if ftype is None:
             warnings.warn(
@@ -619,18 +886,8 @@ class Options(Mapping):
                     "(TYPE_STRING) instead.".format(ftype=ftype)
                 )
             )
-            return six.u(value)
+            return value.decode("utf-8")
 
-        _numeric_types = {
-            TYPE_U8: "B",
-            TYPE_I8: "b",
-            TYPE_U16: "H",
-            TYPE_I16: "h",
-            TYPE_U32: "I",
-            TYPE_I32: "i",
-            TYPE_U64: "Q",
-            TYPE_I64: "q",
-        }
         if ftype in _numeric_types:
             fmt = self.endianness + _numeric_types[ftype]
             return struct.unpack(fmt, value)[0]
@@ -656,6 +913,93 @@ class Options(Mapping):
         if ftype == TYPE_EUIADDR:
             return unpack_euiaddr(value)
 
+        if ftype == TYPE_TYPE_BYTES:
+            return (value[0], value[1:])
+
+        if ftype == TYPE_EPBFLAGS:
+            fmt = self.endianness + _numeric_types[TYPE_U32]
+            flg = struct.unpack(fmt, value)[0]
+            return EPBFlags(flg)
+
+        if ftype == TYPE_OPT_CUSTOM_STR:
+            fmt = self.endianness + _numeric_types[TYPE_U32]
+            return (struct.unpack(fmt, value[0:4]), value[4:].decode("utf-8"))
+
+        if ftype == TYPE_OPT_CUSTOM_BYTES:
+            fmt = self.endianness + _numeric_types[TYPE_U32]
+            return (struct.unpack(fmt, value[0:4]), value[4:])
+
+        raise ValueError("Unsupported field type: {0}".format(ftype))
+
+    def _encode_value(self, value, ftype):
+
+        if ftype is None:
+            warnings.warn(
+                DeprecationWarning(
+                    'Field type should not be "None". Please explicitly '
+                    "use TYPE_BYTES instead."
+                )
+            )
+            assert isinstance(value, (bytes, bytearray))
+            return value
+
+        if ftype == TYPE_BYTES:
+            assert isinstance(value, (bytes, bytearray))
+            return value
+
+        if hasattr(ftype, "__call__"):
+            # TODO figure out how callable options work
+            return ftype(value, self.endianness)
+
+        if ftype == TYPE_STRING:
+            return value.encode("utf-8")
+
+        if ftype in ("str", "unicode"):
+            warnings.warn(
+                DeprecationWarning(
+                    'The "{ftype}" field type is deprecated. Please use "string" '
+                    "(TYPE_STRING) instead.".format(ftype=ftype)
+                )
+            )
+            return value.encode("utf-8")
+
+        if ftype in _numeric_types:
+            fmt = self.endianness + _numeric_types[ftype]
+            return struct.pack(fmt, value)
+
+        if ftype == TYPE_IPV4:
+            return pack_ipv4(value)
+
+        if ftype == TYPE_IPV4_MASK:
+            return pack_ipv4(value[0]) + pack_ipv4(value[1])
+
+        if ftype == TYPE_IPV6:
+            return pack_ipv6(value)
+
+        if ftype == TYPE_IPV6_PREFIX:
+            return pack_ipv6(value[0]) + value[1]
+
+        if ftype == TYPE_MACADDR:
+            return pack_macaddr(value)
+
+        if ftype == TYPE_EUIADDR:
+            return pack_euiaddr(value)
+
+        if ftype == TYPE_TYPE_BYTES:
+            return value[0] + value[1]
+
+        if ftype == TYPE_EPBFLAGS:
+            fmt = self.endianness + _numeric_types[TYPE_U32]
+            return struct.pack(fmt, int(value))
+
+        if ftype == TYPE_OPT_CUSTOM_STR:
+            fmt = self.endianness + _numeric_types[TYPE_U32]
+            return struct.pack(fmt, value[0]) + value[1].encode("utf-8")
+
+        if ftype == TYPE_OPT_CUSTOM_BYTES:
+            fmt = self.endianness + _numeric_types[TYPE_U32]
+            return struct.pack(fmt, value[0]) + value[1]
+
         raise ValueError("Unsupported field type: {0}".format(ftype))
 
 
@@ -664,10 +1008,11 @@ def struct_decode(schema, stream, endianness="="):
     Decode structured data from a stream, following a schema.
 
     :param schema:
-        a list of two tuples: ````(name, field)``, where ``name`` is a string
-        representing the attribute name, and ``field`` is an instance of a
-        :py:class:`StructField` sub-class, providing a ``.load()`` method
-        to be called on the stream to get the field value.
+        a list of three tuples: ``(name, field, default)``, where ``name`` is a
+        string representing the attribute name, and ``field`` is an instance of
+        a :py:class:`StructField` sub-class, providing a ``.load()`` method to
+        be called on the stream to get the field value. ``default`` is used
+        when manually instantiating a block, but is ignored here.
 
     :param stream:
         a file-like object, providing a ``.read()`` method, from which data
@@ -682,29 +1027,18 @@ def struct_decode(schema, stream, endianness="="):
     """
 
     decoded = {}
-    for name, field in schema:
-        decoded[name] = field.load(stream, endianness=endianness)
+    for name, field, default in schema:
+        decoded[name] = field.load(stream, endianness=endianness, seen=decoded)
     return decoded
+
+
+def block_decode(block, stream):
+    return struct_decode(block.schema, stream, block.section.endianness)
 
 
 def struct_encode(schema, obj, outstream, endianness="="):
     """
-    In the future, this function will be used to encode a structure into
-    a stream. For the moment, it just raises :py:exc:`NotImplementedError`.
+    Encode structured data to a stream.
     """
-    raise NotImplementedError
-
-
-def struct_decode_string(schema, data):
-    """Utility function to pass a string to :py:func:`struct_decode`"""
-    return struct_decode(schema, io.BytesIO())
-
-
-def struct_encode_string(schema, obj):
-    """
-    Utility function to pass a string to :py:func:`struct_encode`
-    and get the result back as a bytes string.
-    """
-    outstream = io.BytesIO()
-    struct_encode(schema, obj, outstream)
-    return outstream.getvalue()
+    for name, field, default in schema:
+        field.encode(getattr(obj, name), outstream, endianness=endianness)

--- a/pcapng/structs.py
+++ b/pcapng/structs.py
@@ -5,8 +5,10 @@ Module providing facilities for handling struct-like data.
 import abc
 import struct
 import warnings
+from collections.abc import Iterable, Mapping
 
 from pcapng import strictness as strictness
+from pcapng._compat import namedtuple
 from pcapng.exceptions import (
     BadMagic,
     CorruptedFile,
@@ -16,9 +18,6 @@ from pcapng.exceptions import (
 )
 from pcapng.flags import FlagBool, FlagEnum, FlagField, FlagUInt, FlagWord
 from pcapng.utils import (
-    Iterable,
-    Mapping,
-    namedtuple,
     pack_euiaddr,
     pack_ipv4,
     pack_ipv6,
@@ -689,7 +688,7 @@ class Options(Mapping):
           section 3.5.1)
 
     :param data:
-        Initial data for the options. A list of two-tuples: ``(code, value)``.
+        Initial data for the options. A dict of ``code: value`` items.
         Items with the same code may be repeated; only the first one will be
         accessible using subscript ``options[code]``; the others can be
         accessed using :py:meth:`get_all` and related methods
@@ -709,7 +708,7 @@ class Options(Mapping):
     def __init__(self, schema, data, endianness):
         self.schema = {}  # Schema of option fields: {<code>: Option(...)}
         self._field_names = {}  # Map names to codes
-        self.data = {}  # List of (code, value) tuples
+        self.data = {}  # option data, with numeric option IDs as keys
         self.endianness = endianness  # one of '<>!='
 
         # This is the default schema, common to all objects

--- a/pcapng/utils.py
+++ b/pcapng/utils.py
@@ -1,12 +1,5 @@
 import socket
 import struct
-from collections import namedtuple as _namedtuple
-
-# These are here for export, hence ignoring F401 warning
-try:
-    from collections.abc import Iterable, Mapping  # NOQA:F401
-except ImportError:
-    from collections import Iterable, Mapping  # NOQA:F401
 
 
 def pack_ipv4(data):
@@ -87,23 +80,3 @@ def pack_timestamp_resolution(base, exponent):
     if base == 10:
         return struct.pack("B", exponent)
     raise ValueError("Supported bases are: 2, 10")
-
-
-# version-portable namedtuple with defaults, adapted from
-# https://stackoverflow.com/a/18348004/6692652
-def namedtuple(typename, field_names, defaults=None):
-    if not defaults:
-        # No defaults given or needed
-        return _namedtuple(typename, field_names)
-    try:
-        # Python 3.7+
-        return _namedtuple(typename, field_names, defaults=defaults)
-    except TypeError:
-        T = _namedtuple(typename, field_names)
-        try:
-            # Python 2.7, up to 3.6
-            T.__new__.__defaults__ = defaults
-        except AttributeError:
-            # Older Python 2.x
-            T.__new__.func_defaults = defaults
-        return T

--- a/pcapng/writer.py
+++ b/pcapng/writer.py
@@ -1,0 +1,75 @@
+import pcapng.blocks as blocks
+from pcapng.exceptions import PcapngDumpError
+
+
+class FileWriter(object):
+    """
+    pcap-ng file writer.
+    """
+
+    __slots__ = [
+        "stream",
+        "interfaces",
+        "current_section",
+    ]
+
+    def __init__(self, stream, shb):
+        """
+        Start writing a new pcap-ng section to the given stream. Writes the
+        :py:class:`SectionHeader` immediately. Also writes any
+        :py:class:`InterfaceDescription` blocks that have been created for
+        the section.
+
+        :param stream:
+            a file-like object to which to write the data.
+
+        :param shb:
+            a :py:class:`pcapng.blocks.SectionHeader` to start the section.
+        """
+        self.stream = stream
+        self.interfaces = set()
+        if not isinstance(shb, blocks.SectionHeader):
+            raise TypeError("not a SectionHeader")
+        self.current_section = shb
+        shb._write(self.stream)
+        for iface in sorted(shb.interfaces.keys()):
+            self.interfaces.add(iface)
+            shb.interfaces[iface]._write(stream)
+
+    def write_block(self, blk):
+        """
+        Write the given block to this stream.
+
+        If the block is a :py:class:`pcapng.blocks.SectionHeader`, then a new
+        section will be started in the same output stream, along with any
+        :py:class:`InterfaceDescription` blocks that have been created for the section.
+
+        :param blk:
+            a :py:class:`pcapng.blocks.Block` to write.
+        """
+        if not isinstance(blk, blocks.Block):
+            raise TypeError("not a pcapng block")
+
+        if type(blk) is blocks.SectionHeader:
+            # Starting a new section, so re-initialize
+            self.__init__(self.stream, blk)
+            return
+
+        if blk.section is not self.current_section:
+            raise PcapngDumpError("block not from current section")
+
+        if type(blk) is blocks.InterfaceDescription:
+            # Have we already written this interface?
+            if blk.interface_id in self.interfaces:
+                # We have. Should this be an error?
+                raise PcapngDumpError(
+                    "duplicate interface_id {}".format(blk.interface_id)
+                )
+            # No, so add it
+            self.interfaces.add(blk.interface_id)
+        elif isinstance(blk, blocks.BlockWithInterfaceMixin):
+            # Check that we've written the interface for this block
+            if blk.interface.interface_id not in self.interfaces:
+                raise PcapngDumpError("no matching interface written for block")
+
+        blk._write(self.stream)

--- a/tests/test_parse_exceptions.py
+++ b/tests/test_parse_exceptions.py
@@ -9,7 +9,7 @@ from pcapng.blocks import SectionHeader
 
 def test_get_nonexistent_block_attribute():
     shb = SectionHeader(
-        b"\x00\x01\x00\x00" b"\xff\xff\xff\xff\xff\xff\xff\xff" b"\x00\x00\x00\x00",
+        raw=b"\x00\x01\x00\x00" b"\xff\xff\xff\xff\xff\xff\xff\xff" b"\x00\x00\x00\x00",
         endianness=">",
     )
 

--- a/tests/test_parse_interface_block.py
+++ b/tests/test_parse_interface_block.py
@@ -47,7 +47,7 @@ def test_read_block_interface_bigendian():
     assert blocks[1].options["if_tsresol"] == b"\x06"
     assert blocks[1].timestamp_resolution == 1e-6
     assert blocks[1].options["if_os"] == "Linux 3.2.0-4-amd64"
-    assert blocks[1].reserved == b"\x00\x00"
+    assert blocks[1].reserved == 0
 
     assert repr(blocks[1]) == (
         "<InterfaceDescription link_type=1 reserved={reserved} "

--- a/tests/test_parse_wireshark_capture_files.py
+++ b/tests/test_parse_wireshark_capture_files.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcapng.blocks import InterfaceDescription, Packet, SectionHeader
+from pcapng.blocks import InterfaceDescription, ObsoletePacket, SectionHeader
 from pcapng.scanner import FileScanner
 
 
@@ -147,8 +147,28 @@ def test_sample_test006_ntar(filename):
 
         assert blocks[1].options["if_description"] == "Stupid ethernet interface\x00"
 
-        assert isinstance(blocks[2], Packet)
+        assert isinstance(blocks[2], ObsoletePacket)
         assert blocks[2].interface_id == 0
+        assert blocks[2].options["pack_flags"].inout == "NA"
+        assert blocks[2].options["pack_flags"].casttype == "NA"
+        assert blocks[2].options["pack_flags"].fcslen == 0
+        assert blocks[2].options["pack_flags"].reserved == 0
+        assert blocks[2].options["pack_flags"].err_16 is False
+        assert blocks[2].options["pack_flags"].err_17 is False
+        assert blocks[2].options["pack_flags"].err_18 is False
+        assert blocks[2].options["pack_flags"].err_19 is False
+        assert blocks[2].options["pack_flags"].err_20 is False
+        assert blocks[2].options["pack_flags"].err_21 is False
+        assert blocks[2].options["pack_flags"].err_22 is False
+        assert blocks[2].options["pack_flags"].err_23 is False
+        assert blocks[2].options["pack_flags"].err_crc is False
+        assert blocks[2].options["pack_flags"].err_long is False
+        assert blocks[2].options["pack_flags"].err_short is False
+        assert blocks[2].options["pack_flags"].err_frame_gap is False
+        assert blocks[2].options["pack_flags"].err_frame_align is False
+        assert blocks[2].options["pack_flags"].err_frame_delim is False
+        assert blocks[2].options["pack_flags"].err_preamble is False
+        assert blocks[2].options["pack_flags"].err_symbol is False
 
 
 # ============================================================
@@ -187,7 +207,7 @@ def test_sample_test006_ntar(filename):
 # 00000050:                     0000 0000            End of options block
 # 00000050:                               4400 0000  Block total length (68)
 
-# -------------------- Packet --------------------
+# -------------------- Packet (Obsolete) --------------------
 
 # 00000060: 0200 0000                                Block Magic
 # 00000060:           a700 0000                      Block size (167(!??))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,27 +11,25 @@ from pcapng.utils import (
 
 
 def test_unpack_ipv4():
-    assert unpack_ipv4("\x00\x00\x00\x00") == "0.0.0.0"
-    assert unpack_ipv4("\xff\xff\xff\xff") == "255.255.255.255"
-    assert unpack_ipv4("\x0a\x10\x20\x30") == "10.16.32.48"
+    assert unpack_ipv4(b"\x00\x00\x00\x00") == "0.0.0.0"
+    assert unpack_ipv4(b"\xff\xff\xff\xff") == "255.255.255.255"
+    assert unpack_ipv4(b"\x0a\x10\x20\x30") == "10.16.32.48"
 
 
 def test_unpack_ipv6():
     assert (
-        unpack_ipv6(
-            "\x00\x11\x22\x33\x44\x55\x66\x77" "\x88\x99\xaa\xbb\xcc\xdd\xee\xff"
-        )
-        == "0011:2233:4455:6677:8899:aabb:ccdd:eeff"
+        unpack_ipv6(b"\x00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff")
+        == "11:2233:4455:6677:8899:aabb:ccdd:eeff"
     )
 
 
 def test_unpack_macaddr():
-    assert unpack_macaddr("\x00\x11\x22\xaa\xbb\xcc") == "00:11:22:aa:bb:cc"
+    assert unpack_macaddr(b"\x00\x11\x22\xaa\xbb\xcc") == "00:11:22:aa:bb:cc"
 
 
 def test_unpack_euiaddr():
     assert (
-        unpack_euiaddr("\x00\x11\x22\x33\xaa\xbb\xcc\xdd") == "00:11:22:33:aa:bb:cc:dd"
+        unpack_euiaddr(b"\x00\x11\x22\x33\xaa\xbb\xcc\xdd") == "00:11:22:33:aa:bb:cc:dd"
     )
 
 

--- a/tests/test_write_support.py
+++ b/tests/test_write_support.py
@@ -1,0 +1,189 @@
+import io
+
+import pytest
+
+import pcapng.blocks as blocks
+from pcapng import FileScanner, FileWriter
+from pcapng.exceptions import PcapngStrictnessError, PcapngStrictnessWarning
+from pcapng.strictness import Strictness, set_strictness
+
+
+def compare_blocklists(list1, list2):
+    "Compare two lists of blocks. Helper for the below tests."
+
+    assert len(list1) == len(list2)
+
+    for i in range(0, len(list1)):
+        assert list1[i] == list2[i], "block #{} mismatch".format(i)
+
+
+def test_write_read_all_blocks():
+    # Track the blocks we're writing
+    out_blocks = []
+
+    # Build our original/output session
+    o_shb = blocks.SectionHeader(
+        options={
+            "shb_hardware": "pytest",
+            "shb_os": "python",
+            "shb_userappl": "python-pcapng",
+        }
+    )
+    out_blocks.append(o_shb)
+
+    o_idb = o_shb.new_member(
+        blocks.InterfaceDescription,
+        link_type=1,
+        snaplen=65535,
+        options={
+            "if_name": "Interface Zero",
+            "if_description": "Test interface",
+            "if_os": "python",
+            "if_hardware": "whatever",
+        },
+    )
+    out_blocks.append(o_idb)
+
+    # The SHB and IDBs will be written right away here.
+    fake_file = io.BytesIO()
+    writer = FileWriter(fake_file, o_shb)
+
+    # Add blocks to the output
+
+    # epb
+    blk = o_shb.new_member(blocks.EnhancedPacket)
+    blk.packet_data = b"Test data 123 XYZ"
+    writer.write_block(blk)
+    out_blocks.append(blk)
+
+    # spb
+    blk = o_shb.new_member(blocks.SimplePacket)
+    blk.packet_data = b"Test data 123 XYZ"
+    writer.write_block(blk)
+    out_blocks.append(blk)
+
+    # pb (which is obsolete)
+    set_strictness(Strictness.FORBID)
+    blk = o_shb.new_member(blocks.ObsoletePacket)
+    blk.packet_data = b"Test data 123 XYZ"
+    with pytest.raises(PcapngStrictnessError, match="obsolete"):
+        # Should prevent writing by default
+        writer.write_block(blk)
+
+    # Set to warning mode and try again
+    set_strictness(Strictness.WARN)
+    with pytest.warns(PcapngStrictnessWarning, match="obsolete"):
+        # Should write the obsolete block now
+        writer.write_block(blk)
+    out_blocks.append(blk)
+
+    # Set to fix mode and try again
+    set_strictness(Strictness.FIX)
+    with pytest.warns(PcapngStrictnessWarning, match="obsolete"):
+        # Should write an enhanced block now
+        writer.write_block(blk)
+    out_blocks.append(blk.enhanced())
+
+    set_strictness(Strictness.FORBID)
+
+    # nrb
+    blk = o_shb.new_member(
+        blocks.NameResolution,
+        records=[
+            {
+                "type": 1,
+                "address": "127.0.0.1",
+                "names": ["localhost", "localhost.localdomain"],
+            },
+            {
+                "type": 2,
+                "address": "::1",
+                "names": ["localhost", "localhost.localdomain"],
+            },
+        ],
+    )
+    writer.write_block(blk)
+    out_blocks.append(blk)
+
+    # isb
+    blk = o_shb.new_member(
+        blocks.InterfaceStatistics,
+        interface_id=0,
+        timestamp_high=0x01234567,
+        timestamp_low=0x89ABCDEF,
+        options={
+            "isb_starttime": 0x0123456789ABCD00,
+            "isb_endtime": 0x0123456789ABCDEF,
+            "isb_usrdeliv": 50,
+        },
+    )
+    writer.write_block(blk)
+    out_blocks.append(blk)
+
+    # Done writing blocks.
+    # Now get back what we wrote and see if things line up.
+    fake_file.seek(0)
+    in_blocks = list(FileScanner(fake_file))
+
+    compare_blocklists(in_blocks, out_blocks)
+
+
+def test_spb_snap_lengths():
+    """
+    Simple Packet Blocks present a unique challenge in parsing. The packet does not
+    contain an explicit "captured length" indicator, only the original observed
+    packet length; one must consult the capturing network interface's snap length
+    in order to determine whether the packet may have been truncated.
+
+    The block interface was designed to take care of most of this for the developer,
+    both for reading and writing. For reading, the :py:method:`captured_len` is
+    a property that works out its value from the capturing interface and the original
+    packet length. For writing, packet data will be truncated to the capturing
+    interface's snap length if it would be too big.
+    """
+
+    # Binary data to write/test
+    data = bytes(range(0, 256))
+
+    # First session: no snap length
+    o_shb = blocks.SectionHeader()
+    o_idb = o_shb.new_member(blocks.InterfaceDescription)  # noqa: F841
+    o_blk1 = o_shb.new_member(blocks.SimplePacket, packet_data=data)
+
+    fake_file = io.BytesIO()
+    writer = FileWriter(fake_file, o_shb)
+    writer.write_block(o_blk1)
+
+    fake_file.seek(0)
+    (i_shb, i_idb, i_blk1) = list(FileScanner(fake_file))
+    assert i_blk1.captured_len == len(data)
+    assert i_blk1.packet_len == len(data)
+    assert i_blk1.packet_data == data
+
+    # Second session: with snap length
+    o_shb = blocks.SectionHeader()
+    o_idb = o_shb.new_member(blocks.InterfaceDescription, snaplen=32)  # noqa: F841
+    o_blk1 = o_shb.new_member(blocks.SimplePacket, packet_data=data[:16])
+    o_blk2 = o_shb.new_member(blocks.SimplePacket, packet_data=data[:32])
+    o_blk3 = o_shb.new_member(blocks.SimplePacket, packet_data=data[:33])
+
+    fake_file = io.BytesIO()
+    writer = FileWriter(fake_file, o_shb)
+    writer.write_block(o_blk1)
+    writer.write_block(o_blk2)
+    writer.write_block(o_blk3)
+
+    fake_file.seek(0)
+    (i_shb, i_idb, i_blk1, i_blk2, i_blk3) = list(FileScanner(fake_file))
+
+    assert i_blk1.captured_len == 16
+    assert i_blk1.packet_len == 16
+    assert i_blk1.packet_data == data[:16]
+
+    assert i_blk2.captured_len == 32
+    assert i_blk2.packet_len == 32
+    assert i_blk2.packet_data == data[:32]
+
+    assert i_blk3.captured_len == 32
+    assert i_blk3.packet_len == 33
+    assert i_blk3.packet_data == data[:32]


### PR DESCRIPTION
As discussed in issue #14, I took tannewt's work as a starting point and went from there. Some highlights:

* `examples/generate_pcapng.py`
    * New example script, shows the absolute minimum necessary to create a compliant pcapng file from pure python code.
* `pcapng/strictness.py`
    * Methods to make it easier to deal with pcapng structures that aren't fully broken, but which go against the pcapng spec. (eg, writing a packet block before writing any InterfaceDescription it could reference.)
    * Default is to forbid such problems, but coders can have it auto-fix problems where possible, just warn about them, or even ignore them entirely.
* `pcapng/blocks.py`
    * All block schemas have a third member in their tuple, to hold the default value for that field when creating a block from code (rather than loading from a file).
    * Blocks can have read-only fields, so users can get an error when trying to change them instead of being frustrated when their code seemingly has no effect.
    * Added a `SectionHeader.new_member()` method to easily create blocks which are members of the section header from which this method was called. (See change to `pcapng/scanner.py`)
    * Slightly expanded the scope of `BlockWithInterfaceMixin` so it's used in any block that has/requires an interface. This includes all forms of packet block, and InterfaceStatistics.
    * Slightly changed the scope of `BasePacketBlock` so it's used for any and all blocks that contain packet data.
        * Provides a read-only `captured_len` property that returns the length of the actual packet data.
        * The `packet_len` property defaults to the captured length of the packet if the user doesn't provide one when creating a new packet block. (Does not affect loading blocks from a file.)
    * Fixed loading a `SimplePacket` block so it doesn't assume its `captured_len` is identical to its `packet_len`. (`captured_len` can be less than `packet_len` if the capturing interface's snap length is shorter.)
    * Renamed `Packet` to `ObsoletePacket` to reflect that they aren't to be used in new files. Added a `ObsoletePacket.enhanced()` method to return an `EnhancedPacket` version of the same data.
* `pcapng/scanner.py`
    * Changed the API from using class method `block.from_context()` to the more easily understood and self-enforcing `section_header_block.new_member()`.
* `pcapng/flags.py`
    * New file meant to make it as easy to create bitwise field flags in a larger field as it currently is to add fields or options to a schema. Perhaps massive overkill for the single use case I have in mind, but it was good practice for me, and (hopefully) keeps things more consistent with how the rest of the codebase does things.
* `pcapng/structs.py`
    * New `epb_flags` type which is a flag field defined with the aforementioned `pcapng/flags.py`.
    * New `type_bytes` type for the several field types where the first byte is a type indicator which informs the parsing of the remainder.
    * New `opt_custom_str` and `opt_custom_bytes` option types for handdling custom options as defined by the spec.
    * Removed the `PacketDataField` and `SimplePacketDataField` types.
        * These types were being returned to the caller as a tuple, even though the member holding `captured_len` is redundant (since the length of the captured bytes returned will just be that length) and could get out of sync.
        * Instead, there's a `PacketBytes` type which just contains the raw bytes.
        * In `pcapng/blocks.py`, block schemas now include the `captured_len` (if available) and `packet_len` fields as separate, and give `PacketBytes` the name of the field which holds the number of bytes to fetch.
        * Unfortunately, this does make things slightly less pretty within `SimplePacket`. But I feel like this hides less information from the user (the schema for each packet-type block looks exactly like the block definition in the spec).
    * Changed `NameResolutionRecordField` to return/accept a list of domain names, since the spec says there can be more than one.
    * Added a `named_tuple` class called `Option` to keep the interface for specifying a block's possible options easy to read while also allowing for default values (eg. normally not allowing multiples).
* All tests have been updated to use the new API.
    * The tests also were helpful in finding problems with the added API.

Additional notes:
* The README doesn't really need to be part of the merge.
* I've changed `pcapng/blocks.py` to use slots instead of `__dict__` since it's [reportedly](https://stackoverflow.com/questions/472000/usage-of-slots) more performant. This is not required and can be ignored by not merging the relevant commit.
* For writing out options, the function `Options._encode_value()` was based on `Options._convert_value()` (which I renamed to `_decode_value()` for clarity). One case I didn't handle was the `__call__` case because I don't understand it. It's marked with a TODO comment.