### PR TITLE
Fix some encoding bugs.

### DIFF
--- a/pcapng/structs.py
+++ b/pcapng/structs.py
@@ -988,7 +988,7 @@ class Options(Mapping):
             return pack_euiaddr(value)
 
         if ftype == TYPE_TYPE_BYTES:
-            return value[0] + value[1]
+            return value
 
         if ftype == TYPE_EPBFLAGS:
             fmt = self.endianness + _numeric_types[TYPE_U32]
@@ -996,11 +996,11 @@ class Options(Mapping):
 
         if ftype == TYPE_OPT_CUSTOM_STR:
             fmt = self.endianness + _numeric_types[TYPE_U32]
-            return struct.pack(fmt, value[0]) + value[1].encode("utf-8")
+            return struct.pack(fmt, value[0:4]) + value[4:].encode("utf-8")
 
         if ftype == TYPE_OPT_CUSTOM_BYTES:
             fmt = self.endianness + _numeric_types[TYPE_U32]
-            return struct.pack(fmt, value[0]) + value[1]
+            return struct.pack(fmt, value[0:4]) + value[4:]
 
         raise ValueError("Unsupported field type: {0}".format(ftype))
 

--- a/tests/test_write_support.py
+++ b/tests/test_write_support.py
@@ -40,6 +40,7 @@ def test_write_read_all_blocks():
             "if_description": "Test interface",
             "if_os": "python",
             "if_hardware": "whatever",
+            "if_filter": b"\x00tcp port 23 and host 192.0.2.5",
         },
     )
     out_blocks.append(o_idb)


### PR DESCRIPTION
Fix some encoding bugs that pop up during writing.

In current master, supplying an `if_filter` option in an `Interface Description Block`, as shown in the following minimal example, leads to a runtime error.

The reason is that `value` is of type `type+bytes`, and thus expected to be a bytes-like object. The same `TypeError` occurs when trying to add the `epb_hash` option to an `Enhanced Packet Block`.

I have checked that the filter description is correctly reported in Wireshark with the current fix and have added the example filter of the latest draft at https://tools.ietf.org/html/draft-tuexen-opsawg-pcapng to the writer test.

I also noted that the encoding of `TYPE_OPT_CUSTOM_STR` and `TYPE_OPT_CUSTOM_BYTES` is certainly wrong, as it is not the inverse of the decoding operation, so I also corrected that.

```python
#!/usr/bin/env python3

import pcapng

with open('dummy.pcapng', 'wb') as f:
    shb = pcapng.blocks.SectionHeader()
    writer = pcapng.FileWriter(f, shb)

    # Try to add an IDB with an `if_filter` option.
    idb = shb.new_member(
        pcapng.blocks.InterfaceDescription,
        link_type=1,
        snaplen=65535,
        options={
            "if_filter": b"\x00tcp port 23 and host 192.0.2.5",
        })

    writer.write_block(idb)
```

leads to the following error:

```
Traceback (most recent call last):
  File "reproduce_bug.py", line 18, in <module>
    writer.write_block(idb)
  File "/tmp/python-pcapng/pcapng/writer.py", line 75, in write_block
    blk._write(self.stream)
  File "/tmp/python-pcapng/pcapng/blocks.py", line 78, in _write
    self._encode(encoded_block)
  File "/tmp/python-pcapng/pcapng/blocks.py", line 94, in _encode
    field.encode(
  File "/tmp/python-pcapng/pcapng/structs.py", line 380, in encode
    write_options(stream, options)
  File "/tmp/python-pcapng/pcapng/structs.py", line 602, in write_options
    write_int(len(value), stream, 16, False, options.endianness)
TypeError: object of type 'int' has no len()
```