### PR TITLE
Fix `type+bytes` type encoding + add examples.

### DIFF
--- a/examples/generate_pcapng.py
+++ b/examples/generate_pcapng.py
@@ -19,7 +19,8 @@ shb = blocks.SectionHeader(
 idb = shb.new_member(
     blocks.InterfaceDescription,
     link_type=1,
-    options={"if_description": "Hand-rolled", "if_os": "Python"},
+    options={"if_description": "Hand-rolled", "if_os": "Python",
+             "if_filter": [(0, b"tcp port 23 and host 192.0.2.5")]},
 )
 
 # FileWriter() immediately writes the SHB and any IDBs you've added to it

--- a/examples/generate_pcapng.py
+++ b/examples/generate_pcapng.py
@@ -19,8 +19,11 @@ shb = blocks.SectionHeader(
 idb = shb.new_member(
     blocks.InterfaceDescription,
     link_type=1,
-    options={"if_description": "Hand-rolled", "if_os": "Python",
-             "if_filter": [(0, b"tcp port 23 and host 192.0.2.5")]},
+    options={
+        "if_description": "Hand-rolled",
+        "if_os": "Python",
+        "if_filter": [(0, b"tcp port 23 and host 192.0.2.5")],
+    },
 )
 
 # FileWriter() immediately writes the SHB and any IDBs you've added to it

--- a/pcapng/structs.py
+++ b/pcapng/structs.py
@@ -988,7 +988,7 @@ class Options(Mapping):
             return pack_euiaddr(value)
 
         if ftype == TYPE_TYPE_BYTES:
-            return value[0] + value[1]
+            return struct.pack("B", value[0]) + value[1]
 
         if ftype == TYPE_EPBFLAGS:
             fmt = self.endianness + _numeric_types[TYPE_U32]

--- a/tests/test_write_support.py
+++ b/tests/test_write_support.py
@@ -40,6 +40,7 @@ def test_write_read_all_blocks():
             "if_description": "Test interface",
             "if_os": "python",
             "if_hardware": "whatever",
+            "if_filter": [(0, b"tcp port 23 and host 192.0.2.5")],
         },
     )
     out_blocks.append(o_idb)


### PR DESCRIPTION
It seems that it is not so trivial to add a "type+bytes" option to a block (see #34 for some confusion).

This PR ensures that an option of this type can be passed as `(int, bytes)`, which corresponds to the type of the object returned by the decoding function (such that the writer unit test passes).

I have also added an example to spare other people some potential time in the future :).
Note that the option has to be wrapped in `[]` brackets, as otherwise the `tuple` is considered as two separate options that the user wanted to pass (and everything breaks...).