### PR TITLE
Add systemd Journal Export Block.

### DIFF
--- a/examples/generate_pcapng.py
+++ b/examples/generate_pcapng.py
@@ -50,3 +50,7 @@ test_pl = (
 spb = shb.new_member(blocks.SimplePacket)
 spb.packet_data = bytes(test_pl)
 writer.write_block(spb)
+
+jeb = shb.new_member(blocks.SystemdJournalExport)
+spb.journal_entry = bytes("__REALTIME_TIMESTAMP=0\nMESSAGE=Hello!\n", "utf-8")
+writer.write_block(jeb)

--- a/pcapng/blocks.py
+++ b/pcapng/blocks.py
@@ -17,6 +17,7 @@ from pcapng import strictness as strictness
 from pcapng.constants import link_types
 from pcapng.structs import (
     IntField,
+    JournalEntryField,
     ListField,
     NameResolutionRecordField,
     Option,
@@ -47,7 +48,10 @@ class Block(object):
     def __init__(self, **kwargs):
         if "raw" in kwargs:
             self._decoded = struct_decode(
-                self.schema, io.BytesIO(kwargs["raw"]), kwargs["endianness"]
+                self.schema,
+                io.BytesIO(kwargs["raw"]),
+                kwargs["endianness"],
+                len(kwargs["raw"]),
             )
         else:
             self._decoded = {}
@@ -647,6 +651,24 @@ class InterfaceStatistics(
             ),
             None,
         ),
+    ]
+
+
+@register_block
+class SystemdJournalExport(SectionMemberBlock):
+    """
+    "The systemd Journal Export Block is a lightweight container for systemd
+    Journal Export Format entry data. [...] Although the primary use of this
+    block is intended for importing data from systemd, it could potentially
+    be used to include arbitrary key-value data in a capture file."
+    - pcapng spec, section 4.7. Other quoted citations are from this section
+    unless otherwise noted.
+    """
+
+    magic_number = 0x00000009
+    __slots__ = []
+    schema = [
+        ("journal_entry", JournalEntryField(), b""),
     ]
 
 

--- a/tests/test_write_support.py
+++ b/tests/test_write_support.py
@@ -121,6 +121,16 @@ def test_write_read_all_blocks():
     writer.write_block(blk)
     out_blocks.append(blk)
 
+    # systemd Journal Export Block.
+    blk = o_shb.new_member(
+        blocks.SystemdJournalExport,
+        journal_entry=bytes(
+            "__REALTIME_TIMESTAMP=0\nMESSAGE=Hello!\nPRIORITY=6\n", "utf-8"
+        ),
+    )
+    writer.write_block(blk)
+    out_blocks.append(blk)
+
     # Done writing blocks.
     # Now get back what we wrote and see if things line up.
     fake_file.seek(0)


### PR DESCRIPTION
Add systemd Journal Export Block.
- I had to add a "maximum size" to the stream-based decoding routines, as the total block length is needed to deduce the size of the `Journal Entry` field, but was unavailable there. Note that this is the first time we need the total block length during parsing. Previously, tricks with `seen` list of earlier parsed header fields was all we needed.
- Note that the `Journal Entry` field is of type bytes, see https://github.com/pcapng/pcapng and https://www.freedesktop.org/wiki/Software/systemd/export/
- Note that the function `decode_block` in `pcapng/structs.py` is never used, so I removed it.